### PR TITLE
Améliorer le header : badge beta + logo intitulé + lien créer un diag

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -128,6 +128,7 @@ TEMPLATES = [
                 "users.context_processors.add_connected_user_to_context",
                 "django_app_parameter.context_processors.add_global_parameter_context",
                 "csp.context_processors.nonce",
+                "dsfr.context_processors.site_config",
             ],
         },
     },

--- a/templates/header.html
+++ b/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block service_title %}
 <a href="/" title="Accueil — SPARTE">
-    <p class="fr-header__service-title">SPARTE</p>
+    <p class="fr-header__service-title">SPARTE <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
 </a>
 {% endblock service_title %}
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -6,8 +6,13 @@
 </a>
 {% endblock service_title %}
 
-<!-- {% block header_tools %}
-{% endblock header_tools %} -->
+{% block header_tools %}
+<li>
+  <a class="fr-btn fr-fi-add-circle-line" href="{% url 'project:select' %}">
+    Créer un diagnostic
+  </a>
+</li>
+{% endblock header_tools %}
 
 {# Leave burger_menu and main_menu blocks empty if the main menu is not used #}
 {# block burger_menu #}

--- a/templates/header.html
+++ b/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block service_title %}
 <a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
-    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
+    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--blue-cumulus">Beta</sup></p>
 </a>
 {% endblock service_title %}
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,12 +1,10 @@
 {% extends "dsfr/header.html" %}
 
 {% block service_title %}
-<a href="/" title="Accueil — SPARTE">
-    <p class="fr-header__service-title">SPARTE <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
+<a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
+    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
 </a>
 {% endblock service_title %}
-
-{% block service_tagline %}Mesurer votre consommation d'espace et l'artificialisation de votre territoire{% endblock service_tagline %}
 
 <!-- {% block header_tools %}
 {% endblock header_tools %} -->


### PR DESCRIPTION
Dans cette PR, j'ai peaufiné le header avec :
- ajout d'un badge "beta"
- ajouter le bon intitulé sur le logo avec la Marianne
- ajouter un lien pour créer un diagnostic car ça n'etait plus accessible partout depuis le site (ça me semblait une bonne idée au vu du changement de la navigation - mais on peut en rediscuter).

<img width="1263" alt="Capture d’écran 2022-07-29 à 14 52 00" src="https://user-images.githubusercontent.com/6756627/181764515-c06fb251-deb4-484f-9add-6a47571e3f37.png">



Variables configurées dans l'admin
<img width="544" alt="Capture d’écran 2022-07-29 à 10 05 22" src="https://user-images.githubusercontent.com/6756627/181713972-8a4bb604-756e-4259-9697-81934ee16731.png">

