### PR TITLE
ntégrer le nouveau design - footer

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -128,6 +128,7 @@ TEMPLATES = [
                 "users.context_processors.add_connected_user_to_context",
                 "django_app_parameter.context_processors.add_global_parameter_context",
                 "csp.context_processors.nonce",
+                "dsfr.context_processors.site_config",
             ],
         },
     },

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,6 +1,4 @@
-{% extends "dsfr/footer.html" %}
-
-<footer role="contentinfo" class="fr-footer" id="footer">
+<footer role="contentinfo" class="fr-footer fr-mt-5w" id="footer">
   <div class="fr-container">
     <div class="fr-footer__body">
       <div class="fr-footer__brand fr-enlarge-link">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,0 +1,63 @@
+{% extends "dsfr/footer.html" %}
+
+<footer role="contentinfo" class="fr-footer" id="footer">
+  <div class="fr-container">
+    <div class="fr-footer__body">
+      <div class="fr-footer__brand fr-enlarge-link">
+        <a href="/" title="Retour à l’accueil">
+          {% block brand %}
+            <p class="fr-logo" title="{{ SITE_CONFIG.footer_brand|default:'république française' }}">
+              {{ SITE_CONFIG.footer_brand_html| default_if_none:'république<br />française' | safe }}
+            </p>
+          {% endblock brand %}
+        </a>
+      </div>
+      <div class="fr-footer__content">
+        <p class="fr-footer__content-desc">
+          {% block footer_content %}
+            {{ SITE_CONFIG.footer_description | safe }}
+            <br><br>
+            Le code source est ouvert et les contributions sont bienvenues.
+            <a href="https://github.com/MTES-MCT/sparte" target="_blank" rel="noopener" title="Voir le code source - nouvelle fenêtre">Voir le code source</a>
+          {% endblock footer_content %}</p>
+        <ul class="fr-footer__content-list">
+          <li class="fr-footer__content-item">
+            <a class="fr-footer__content-link" href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a class="fr-footer__content-link" href="https://gouvernement.fr">gouvernement.fr</a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a class="fr-footer__content-link" href="https://service-public.fr">service-public.fr</a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a class="fr-footer__content-link" href="https://data.gouv.fr">data.gouv.fr</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="fr-footer__bottom">
+      <ul class="fr-footer__bottom-list">
+        {% block footer_links %}
+          <li class="fr-footer__bottom-item">
+            <a class="fr-footer__bottom-link" href="{% url 'home:accessibilite' %}">Accessibilité: {{ SITE_CONFIG.get_accessibility_status_display|default:'non' }} conforme</a>
+          </li>
+          <li class="fr-footer__bottom-item">
+            <a class="fr-footer__bottom-link" href="{% url 'home:cgv' %}">Mentions légales</a>
+          </li>
+          <li class="fr-footer__bottom-item">
+            <a class="fr-footer__bottom-link" href="{% url 'home:privacy' %}">Données personnelles</a>
+          </li>
+          <li class="fr-footer__bottom-item">
+            <a class="fr-footer__bottom-link" href="{% url 'home:stats' %}">Statistiques</a>
+          </li>
+        {% endblock footer_links %}
+      </ul>
+      <div class="fr-footer__bottom-copy">
+        <p>
+          Sauf mention contraire, tous les textes de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" rel="noopener noreferrer">licence etalab-2.0</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/templates/header.html
+++ b/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block service_title %}
 <a href="/" title="Accueil — SPARTE">
-    <p class="fr-header__service-title">SPARTE</p>
+    <p class="fr-header__service-title">SPARTE <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
 </a>
 {% endblock service_title %}
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -6,8 +6,13 @@
 </a>
 {% endblock service_title %}
 
-<!-- {% block header_tools %}
-{% endblock header_tools %} -->
+{% block header_tools %}
+<li>
+  <a class="fr-btn fr-fi-add-circle-line" href="{% url 'project:select' %}">
+    Créer un diagnostic
+  </a>
+</li>
+{% endblock header_tools %}
 
 {# Leave burger_menu and main_menu blocks empty if the main menu is not used #}
 {# block burger_menu #}

--- a/templates/header.html
+++ b/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block service_title %}
 <a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
-    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
+    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--blue-cumulus">Beta</sup></p>
 </a>
 {% endblock service_title %}
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,12 +1,10 @@
 {% extends "dsfr/header.html" %}
 
 {% block service_title %}
-<a href="/" title="Accueil — SPARTE">
-    <p class="fr-header__service-title">SPARTE <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
+<a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">
+    <p class="fr-header__service-title">{{ SITE_CONFIG.site_title }} <sup class="fr-badge fr-badge--sm fr-badge--green-menthe">Beta</sup></p>
 </a>
 {% endblock service_title %}
-
-{% block service_tagline %}Mesurer votre consommation d'espace et l'artificialisation de votre territoire{% endblock service_tagline %}
 
 <!-- {% block header_tools %}
 {% endblock header_tools %} -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,29 +75,9 @@
                     {% endblock %}
                 </div>
                 {% endblock carto %}
+
                 <!-- Footer-->
-                {% block footer %}
-                <div id="footer" class="border-top py-5 flex-grow-1 mt-5">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col-2">
-                                <img class="w-100" src="{% static 'img/logo_france.png' %}" alt="Logo France Marianne"/>
-                            </div>
-                            <div class="col-10">
-                                <p class="my-3">
-                                    <a href="{% url 'home:cgv' %}">Mentions légales</a> - <a href="{% url 'home:privacy' %}">Politique de confidentialité</a> - <a href="{% url 'home:stats' %}">Statistiques</a> - <a href="{% url 'home:accessibilite' %}">Accessibilité : non conforme</a>
-                                </p>
-                                <p class="text-muted">
-                                    SPARTE est une start-up d'état en cours d'élaboration, la plateforme est en version BETA publique. Faites nous part de vos propositions pour améliorer ce service en envoyant un e-mail à <a href="mailto:sparte@beta.gouv.fr">sparte@beta.gouv.fr</a>. SPARTE est incubée à la Fabrique du numérique du Ministère de la Transition Ecologique, et membre de la communauté <a href="https://www.beta.gouv.fr">Beta Gouv</a>.
-                                </p>
-                                <p class="text-muted">
-                                    Sparte est Open Source, le code est disponible sur github : <a href="https://github.com/MTES-MCT/sparte" target="_blank">https://github.com/MTES-MCT/sparte</a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                {% endblock footer %}
+                {% include "footer.html" %}
                 </div>
             </main>
         </div>


### PR DESCRIPTION
Mise en place du DSFR pour le footer.
J'ai mergé la branche `feature/improve-header` dans cette PR, afin de recuperer la config de la description du footer depuis l'admin, il faut donc juste regarder le dernier commit.

à rediscuter si besoin : 
- Je n'ai pas ajouté le plan du site : je trouvais ça un peu étonnant de ne mettre que 3 liens.
- J'ai repris la phrase pour l'acces au code opensource de la startup d'etat ma cantine.

<img width="1275" alt="Capture d’écran 2022-07-29 à 16 14 06" src="https://user-images.githubusercontent.com/6756627/181779098-dd8e1fb1-c9be-4071-a3a8-b42be8d7439d.png">
