### PR TITLE
import missing icon.css file for the DSFR to work properly after MAJ

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,7 @@
         <link crossorigin="anonymous" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css" integrity="sha256-8M+b2Hj+vy/2J5tZ9pYDHeuPD59KsaEZn1XXj3xVhjg=">
         <!-- Design System CSS -->
         {% sri_static 'dsfr/dist/dsfr/dsfr.min.css' %}
+        {% sri_static 'dsfr/dist/utility/icons/icons.css' %}
         <!-- Override DSFR CSS -->
         {% sri_static "css/navigation.css" %}
         <!-- subtemplate header injection -->


### PR DESCRIPTION
Il manquait juste l'import d'un fichier css lié aux icones  - suite à la MAJ du DSFR.