### PR TITLE
Fix de la valeur intersection_area parfois égale à 0 au lieu de Area(0)

### DIFF
--- a/project/models/project_base.py
+++ b/project/models/project_base.py
@@ -37,7 +37,7 @@ from public_data.models import (
 )
 from public_data.models.administration import Commune
 from public_data.models.mixins import DataColorationMixin
-from utils.db import cast_sum
+from utils.db import cast_sum_area
 
 from .utils import user_directory_path
 
@@ -910,8 +910,8 @@ class Project(BaseProject):
         qs = CommuneSol.objects.filter(city__in=self.cities.all(), year__in=[first_millesime, last_millesime])
         qs = qs.annotate(code_prefix=code_field)
         qs = qs.values("code_prefix")
-        qs = qs.annotate(surface_first=cast_sum("surface", filter=Q(year=first_millesime), divider=1))
-        qs = qs.annotate(surface_last=cast_sum("surface", filter=Q(year=last_millesime), divider=1))
+        qs = qs.annotate(surface_first=cast_sum_area("surface", filter=Q(year=first_millesime), divider=1))
+        qs = qs.annotate(surface_last=cast_sum_area("surface", filter=Q(year=last_millesime), divider=1))
         data = list(qs)
         item_list = list(klass.objects.all().order_by("code"))
         for item in item_list:

--- a/utils/db.py
+++ b/utils/db.py
@@ -8,8 +8,12 @@ from django.db.models.functions import Cast, Coalesce
 Zero = Area(Polygon(((0, 0), (0, 0), (0, 0), (0, 0)), srid=2154))
 
 
-def cast_sum(field, filter=None, divider=10000):
-    """Add all required data to a queryset to sum a field and return a Decimal"""
+def cast_sum_area(field, filter=None, divider=10000):
+    """
+    Sum all area fields and cast the total to DecimalField.
+    The area field is in m², so by default we divide by 10000 to get hectares.
+    """
+
     return Cast(
         Coalesce(Sum(field, filter=filter, default=Zero), 0) / divider,
         DecimalField(max_digits=15, decimal_places=2),


### PR DESCRIPTION
Résoud l'erreur :
```python
AttributeError: 'int' object has no attribute 'sq_m'
```

Qui a lieu lors de l'éxécution de la commande `python manage.py build_commune_data`