### PR TITLE
Feat/disable cache on local env

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -252,26 +252,26 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CACHES: Dict[str, Any] = {}
 
-# if ENVIRONMENT in ["local"]:
-#     CACHES = {
-#         "default": {
-#             "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-#         }
-#     }
-# else:
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": env.str("SCALINGO_REDIS_URL"),
-        "TIMEOUT": 60 * 15,  # 15 minutes
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "MAX_ENTRIES": 1000,
-        },
+if ENVIRONMENT in ["local"]:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
     }
-}
-FANCY_REMEMBER_ALL_URLS = True
-FANCY_REMEMBER_STATS_ALL_URLS = True
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": env.str("SCALINGO_REDIS_URL"),
+            "TIMEOUT": 60 * 15,  # 15 minutes
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "MAX_ENTRIES": 1000,
+            },
+        }
+    }
+    FANCY_REMEMBER_ALL_URLS = True
+    FANCY_REMEMBER_STATS_ALL_URLS = True
 # SESSION
 
 SESSION_CACHE_ALIAS = "default"


### PR DESCRIPTION
Facilite le développement en désactivant le cache sur les env locaux.

Penser à mettre à jour dans son .env la variable ENVIRONMENT=local