### PR TITLE
Fix redis dummy cache

### DIFF
--- a/config/cache_backends.py
+++ b/config/cache_backends.py
@@ -1,0 +1,21 @@
+from django.core.cache.backends.dummy import DummyCache
+
+
+class RedisDummyCache(DummyCache):
+    def ttl(self, key):
+        return 0
+
+    def delete_pattern(self, pattern, version=None):
+        return None
+
+    def get_or_set(self, key, default, timeout=None):
+        return default() if callable(default) else default
+
+    def reinsert_keys(self):
+        return None
+
+    def persist(self, key):
+        return True
+
+    def expire(self, key, timeout):
+        return True

--- a/config/settings.py
+++ b/config/settings.py
@@ -255,7 +255,7 @@ CACHES: Dict[str, Any] = {}
 if ENVIRONMENT in ["local"]:
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            "BACKEND": "config.cache_backends.RedisDummyCache",
         }
     }
 else:


### PR DESCRIPTION
Resoud l'erreur:
```python
AttributeError at /project/nouveau
'DummyCache' object has no attribute 'delete_pattern'
```
Pas testé en profondeur, mais c'est le dummy cache d'une autre lib similaire à celle qu'on utilise, django-redis-cache:
https://github.com/sebleier/django-redis-cache/blob/master/redis_cache/backends/dummy.py

Celui de la lib qu'on utiise a été supprimé en 4.2:
https://github.com/jazzband/django-redis/blob/master/CHANGELOG.rst#django-redis-420-2015-07-03