### PR TITLE
Résolution lenteur de chargement de la page "Mes diagnostics"

### DIFF
--- a/project/templates/project/list.html
+++ b/project/templates/project/list.html
@@ -37,9 +37,6 @@ Mes diagnostics
                             <div class="fr-card__end">
                                 <ul class="fr-tags-group">
                                     <li>
-                                        <p class="fr-tag fr-tag--sm">Surface du territoire:&nbsp;<strong>{{ project.area|floatformat:0 }} ha</strong></p>
-                                    </li>
-                                    <li>
                                         <p class="fr-tag fr-tag--sm">Période demandée:&nbsp;<strong>De {{ project.analyse_start_date }} à {{ project.analyse_end_date }}</strong></p>
                                     </li>
                                     <li>

--- a/project/templates/project/list.html
+++ b/project/templates/project/list.html
@@ -37,6 +37,9 @@ Mes diagnostics
                             <div class="fr-card__end">
                                 <ul class="fr-tags-group">
                                     <li>
+                                        <p class="fr-tag fr-tag--sm">Surface du territoire:&nbsp;<strong>{{ project.area|floatformat:0 }} ha</strong></p>
+                                    </li>
+                                    <li>
                                         <p class="fr-tag fr-tag--sm">Période demandée:&nbsp;<strong>De {{ project.analyse_start_date }} à {{ project.analyse_end_date }}</strong></p>
                                     </li>
                                     <li>

--- a/project/views/crud.py
+++ b/project/views/crud.py
@@ -238,20 +238,11 @@ class ProjectRemoveLookALike(GroupMixin, RedirectURLMixin, DetailView):
 
 
 class ProjectListView(GroupMixin, LoginRequiredMixin, ListView):
-    queryset = Project.objects.all()
     template_name = "project/list.html"
     context_object_name = "projects"  # override to add an "s"
 
     def get_queryset(self):
-        qs = Project.objects.filter(user=self.request.user)
-        for project in qs:
-            if project.cover_image:
-                try:
-                    project.prop_width = 266
-                    project.prop_height = project.cover_image.height * 266 / project.cover_image.width
-                except FileNotFoundError:
-                    project.cover_image = None
-        return qs
+        return Project.objects.filter(user=self.request.user)
 
 
 class SplashScreenView(GroupMixin, DetailView):


### PR DESCRIPTION
- Supprime le queryset redondant avec la fonction get_queryset (6 secondes de temps CPU économisé avec une dizaine de project)
- Cache la surface des territoires de la liste des résultats (36 requêtes SQL économisé avec une dizaine de project, un peu plus de 1 seconde de temps CPU économisé)

En moyenne sur mon poste, le temps de chargement passe de 7 secondes à 200ms.

@smdsgn Est-ce que tu pense qu'on peut supprimer la surface de la liste ?