### PR TITLE
Multiple fix 4.4

### DIFF
--- a/public_data/management/commands/build_artificial_area.py
+++ b/public_data/management/commands/build_artificial_area.py
@@ -110,13 +110,17 @@ class Command(BaseCommand):
             .annotate(geom=MakeValid(Union("intersection")), surface=Sum("intersection_area"))
         )
 
-        for result in qs:
-            ArtificialArea.objects.create(
-                city=city,
-                year=result["year"],
-                mpoly=fix_poly(result["geom"]),
-                surface=result["surface"].sq_m / 10000,
-            )
+        ArtificialArea.objects.bulk_create(
+            [
+                ArtificialArea(
+                    city=city,
+                    year=result["year"],
+                    mpoly=fix_poly(result["geom"]),
+                    surface=result["surface"].sq_m / 10000,
+                )
+                for result in qs
+            ]
+        )
 
     def clean(self, qs):
         logger.info("Delete previous artificial areas")

--- a/public_data/management/commands/build_commune_data.py
+++ b/public_data/management/commands/build_commune_data.py
@@ -99,15 +99,13 @@ class Command(BaseCommand):
         city = qs.first()
         self.build_data(city)
 
-    def __available_millesimes_in_departement(self, city: Commune):
-        return Ocsge.objects.filter(departement=city.departement).distinct("year")
-
     def __calculate_surface_artif(self, city: Commune):
         city.surface_artif = (
             Ocsge.objects.intersect(city.mpoly)
             .filter(
                 is_artificial=True,
                 year=city.last_millesime,
+                departement_id=city.departement_id,
             )
             .aggregate(surface_artif=cast_sum_area("intersection_area"))["surface_artif"]
         )
@@ -126,11 +124,7 @@ class Command(BaseCommand):
         the city is not covered.
         """
         ocsge_count_in_city_center_point = (
-            Ocsge.objects.intersect(city.mpoly)
-            .filter(
-                mpoly__contains=city.mpoly.point_on_surface,
-            )
-            .count()
+            Ocsge.objects.intersect(city.mpoly).filter(mpoly__contains=city.mpoly.point_on_surface).count()
         )
 
         available_millesime_in_departement_count = len(city.get_ocsge_millesimes())
@@ -139,11 +133,12 @@ class Command(BaseCommand):
             ocsge_count_in_city_center_point == available_millesime_in_departement_count
         )
 
-        if has_ocge_coverage:
-            city.ocsge_available = True
+        city.ocsge_available = has_ocge_coverage
 
-    def __calculate_ocsge_first_and_last_millesime(self, city: Commune):
-        queryset = Ocsge.objects.intersect(city.mpoly).distinct("year")
+    def __calculate_ocsge_first_and_last_millesime(self, city: Commune) -> None:
+        queryset = (
+            Ocsge.objects.intersect(city.mpoly).filter(mpoly__contains=city.mpoly.point_on_surface).distinct("year")
+        )
         city.last_millesime = queryset.latest("year").year
         city.first_millesime = queryset.earliest("year").year
 
@@ -151,6 +146,7 @@ class Command(BaseCommand):
         self.__calculate_ocsge_availability(city)
 
         if not city.ocsge_available:
+            city.save()
             return
 
         self.__calculate_ocsge_first_and_last_millesime(city)
@@ -162,11 +158,10 @@ class Command(BaseCommand):
         self.build_commune_diff(city)
 
     def build_commune_sol(self, city: Commune):
-        # Prep data for couverture and usage in CommuneSol
-        # clean data first
         CommuneSol.objects.filter(city=city).delete()
         qs = (
             Ocsge.objects.intersect(city.mpoly)
+            .filter(departement_id=city.departement_id)
             .exclude(matrix=None)
             .values("matrix_id", "year")
             .annotate(surface=cast_sum_area("intersection_area"))
@@ -174,9 +169,10 @@ class Command(BaseCommand):
         CommuneSol.objects.bulk_create([CommuneSol(city=city, **_) for _ in qs])
 
     def build_commune_diff(self, city):
-        # prep data for artif report in CommuneDiff
+        CommuneDiff.objects.filter(city=city).delete()
         qs = (
             OcsgeDiff.objects.intersect(city.mpoly)
+            .filter(departement_id=city.departement_id)
             .values("year_old", "year_new")
             .annotate(
                 new_artif=cast_sum_area("intersection_area", filter=Q(is_new_artif=True)),
@@ -185,17 +181,4 @@ class Command(BaseCommand):
             )
         )
 
-        for result in qs:
-            try:
-                # try to fetch the line if exists
-                city_data = CommuneDiff.objects.get(
-                    city=city,
-                    year_old=result["year_old"],
-                    year_new=result["year_new"],
-                )
-                city_data.new_artif = result["new_artif"]
-                city_data.new_natural = result["new_natural"]
-                city_data.net_artif = result["net_artif"]
-                city_data.save()
-            except CommuneDiff.DoesNotExist:
-                city_data = CommuneDiff.objects.create(city=city, **result)
+        CommuneDiff.objects.bulk_create([CommuneDiff(city=city, **_) for _ in qs])

--- a/public_data/management/commands/build_commune_data.py
+++ b/public_data/management/commands/build_commune_data.py
@@ -110,21 +110,11 @@ class Command(BaseCommand):
             .aggregate(surface_artif=cast_sum_area("intersection_area"))["surface_artif"]
         )
 
-    def __set_ocsge_availability(self, city: Commune) -> bool:
-        city.ocsge_available = bool(city.departement.ocsge_millesimes)
-
-    def __set_ocsge_first_and_last_millesime(self, city: Commune) -> None:
-        city.last_millesime = max(city.departement.ocsge_millesimes)
-        city.first_millesime = min(city.departement.ocsge_millesimes)
-
     def build_data(self, city: Commune):
-        self.__set_ocsge_availability(city)
-
         if not city.ocsge_available:
-            city.save()
+            logger.info(f"No OCSGE data available for {city.name}. Maybe you forgot to run setup_dept?")
             return
 
-        self.__set_ocsge_first_and_last_millesime(city)
         self.__calculate_surface_artif(city)
 
         city.save()

--- a/public_data/management/commands/setup_dept.py
+++ b/public_data/management/commands/setup_dept.py
@@ -2,14 +2,14 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from public_data.models import Departement
+from public_data.models import Commune, Departement
 
 logger = logging.getLogger("management.commands")
 
 config = {
-    "Gers": ["2016", "2019"],
-    "Essonne": ["2018", "2021"],
-    "Seine-et-Marne": ["2017", "2021"],
+    "Gers": [2016, 2019],
+    "Essonne": [2018, 2021],
+    "Seine-et-Marne": [2017, 2021],
 }
 
 
@@ -22,16 +22,29 @@ class Command(BaseCommand):
             is_artif_ready=False,
             ocsge_millesimes=None,
         )
+        Commune.objects.all().update(
+            first_millesime=None,
+            last_millesime=None,
+            ocsge_available=False,
+        )
         logger.info("Done reset, start config")
+
         for name, millesimes in config.items():
             dept = Departement.objects.get(name=name)
             dept.is_artif_ready = True
             dept.ocsge_millesimes = millesimes
             dept.save()
+
+            Commune.objects.filter(departement=dept).update(
+                first_millesime=min(millesimes),
+                last_millesime=max(millesimes),
+                ocsge_available=True,
+            )
+
             logger.info(f"Done {name}: {millesimes}")
+
         qte = Departement.objects.filter(is_artif_ready=True).count()
         if qte == len(config):
             logger.info("%d departement is artif ready", qte)
         else:
             logger.error("%d departement with artif ready instead of %d", qte, len(config))
-        logger.info("End setup departement OCSGE")

--- a/public_data/models/couverture_usage.py
+++ b/public_data/models/couverture_usage.py
@@ -2,8 +2,6 @@
 Ce fichier contient les référentiels CouvertureSol et UsageSol qui sont les deux
 types d'analyse fournies par l'OCSGE.
 """
-from functools import lru_cache
-
 from django.db import models
 
 
@@ -212,7 +210,6 @@ class CouvertureUsageMatrix(models.Model):
         return f"{cs}-{us}:{a}{c}{n}"
 
     @classmethod
-    @lru_cache()
     def matrix_dict(cls):
         _matrix_dict = dict()
 


### PR DESCRIPTION
- Calcule les millesimes d'OCSGE disponibles d'un projet en se basant sur les millesimes disponibles pour chaque departements des villes composant le projet
- Ajoute un filtre par departement aux fonctions faisant référence à la table OCS GE directement, pour éviter les problèmes de superposition avec les limites administratives des departements voisins
- Ajoute la fonction manquante clean à l'OCS GE Essonne
- Ajoute le fonction calculate_fields manquante à l'OCS GE Essonne et Seine-Et-Marne


-----
Pour déployer, deux options:
- Faire un restore et éxécuter mep_440
- Executer les commandes suivantes:
    - python manage.py load_ocsge --item=EssonneOcsge2018
    - python manage.py load_ocsge --item=EssonneOcsge2021
    - python manage.py load_ocsge --item=SeineEtMarneOcsge2017
    - python manage.py load_ocsge --item=SeineEtMarneOcsge2021
    - python manage.py build_commune_data --departement=Essonne
    - python manage.py build_commune_data --departement=Gers
    - python manage.py build_commune_data --departement=Seine-et-Marne
    - python manage.py build_artificial_area --departement=Essonne
    - python manage.py build_artificial_area --departement=Seine-et-Marne
    - reset_first_last
    - build_project_ocsge_status

-- 
Résoud:
https://app.clickup.com/t/8692zee58?comment=90120014597235
https://app.clickup.com/t/8693b4v6e
https://app.clickup.com/t/8693b4vf6
https://app.clickup.com/t/8693b4x7z
https://app.clickup.com/t/8693b52ky
https://app.clickup.com/t/8693b5eav