### PR TITLE
Homogénéisation des unités de surface des entités administratives

### DIFF
--- a/public_data/management/commands/build_administrative_layers.py
+++ b/public_data/management/commands/build_administrative_layers.py
@@ -144,6 +144,7 @@ class Command(BaseCommand):
                         departement=depts[data.dept_id],
                         epci=epcis[data.epci_id],
                         mpoly=fix_poly(data.mpoly),
+                        area=data.mpoly.transform(2154, clone=True).area / 10000,
                     )
                     for data in paginator.page(page)
                 )

--- a/public_data/management/commands/evaluate_city_area.py
+++ b/public_data/management/commands/evaluate_city_area.py
@@ -13,5 +13,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         logger.info("Start evaluation of city area")
-        Commune.objects.all().update(area=Area(Transform("mpoly", 2154)))
+        Commune.objects.all().update(area=Area(Transform("mpoly", 2154)) / 10000)
         logger.info("End evaluation of city area")


### PR DESCRIPTION
US: https://app.clickup.com/t/86936bedf

- Modifie l'unité de surface de `sq_m` à `ha` de `Commune` pour correspondre aux unités de
    - LandMixin -> ha (toutes les autres collectivités)
    - Project.area -> ha
 
----

Pour déployer, lancer la commande `python manage.py evaluate_city_area`