### PR TITLE
Changement de sous-domaine -> mondiagartif.beta.gouv.fr

### DIFF
--- a/documentation/templates/documentation/faq.html
+++ b/documentation/templates/documentation/faq.html
@@ -260,7 +260,7 @@
                 </h3>
                 <!-- id à modifier par vos soins (doit être unique et servira aussi de référence pour l'ancre) -->
                 <div class="fr-collapse" id="accordion-10">
-                    <p>Si vous repérez une erreur dans les données, vous pouvez nous le signaler via <a href="https://mondiagnosticartificialisation.beta.gouv.fr/contact" target="_blank" rel="noopener">notre page de contact</a> ou en envoyant directement un mail à <a href="mailto:mondiagnosticartificialisation@beta.gouv.fr">mondiagnosticartificialisation@beta.gouv.fr</a></p>
+                    <p>Si vous repérez une erreur dans les données, vous pouvez nous le signaler via <a href="/contact" target="_blank" rel="noreferrer">notre page de contact</a> ou en envoyant directement un mail à <a href="mailto:{{ team_email }}">{{ team_email }}</a></p>
                 </div>
             </section>
 
@@ -430,7 +430,7 @@
                 </h3>
                 <!-- id à modifier par vos soins (doit être unique et servira aussi de référence pour l'ancre) -->
                 <div class="fr-collapse" id="accordion-19">
-                    <p>Vous pouvez en effet vous inscrire à notre newsletter pour recevoir toutes les informations liées à Mon Diagnostic Artificialisation, comme les nouvelles fonctionnalités de la plateforme ou les nouveaux millésimes proposés par exemple. Cela se fait <a href="https://mondiagnosticartificialisation.beta.gouv.fr/" target="_blank" rel="noopener">en bas de la page d’accueil</a> de notre site.</p>
+                    <p>Vous pouvez en effet vous inscrire à notre newsletter pour recevoir toutes les informations liées à Mon Diagnostic Artificialisation, comme les nouvelles fonctionnalités de la plateforme ou les nouveaux millésimes proposés par exemple. Cela se fait <a href="{% url 'home:home' %}" target="_blank" rel="noopener">en bas de la page d’accueil</a> de notre site.</p>
                     <div class="col-12 col-md-8">
                         <img class="img-fluid img-thumbnail" src="{% static 'documentation/img/newsletter.jpg' %}" alt="Capture d'écran de la section d'inscription à la newsletter sur la page d'accueil">
                     </div>

--- a/documentation/views.py
+++ b/documentation/views.py
@@ -1,4 +1,5 @@
 from django.views.generic import TemplateView
+from django_app_parameter import app_parameter
 
 from utils.views_mixins import BreadCrumbMixin
 
@@ -12,6 +13,10 @@ class FAQView(BreadCrumbMixin, TemplateView):
             {"title": "FAQ"},
         )
         return breadcrumbs
+
+    def get_context_data(self, **kwargs):
+        kwargs["team_email"] = app_parameter.TEAM_EMAIL
+        return super().get_context_data(**kwargs)
 
 
 class TutorielView(BreadCrumbMixin, TemplateView):

--- a/home/templates/home/privacy.html
+++ b/home/templates/home/privacy.html
@@ -22,7 +22,7 @@
 
         <h2>Responsable du traitement</h2>
 
-        <p>Le responsable du traitement de vos données à caractère personnel est&nbsp;: <a href="mailto:mondiagnosticartificialisation@beta.gouv.fr">mondiagnosticartificialisation@beta.gouv.fr</a></p>
+        <p>Le responsable du traitement de vos données à caractère personnel est&nbsp;: <a href="mailto:{{ team_email }}">{{ team_email }}</a></p>
 
         <h2>Traitement des données et utilisation</h2>
 
@@ -49,7 +49,7 @@
         <p>En application du règlement général sur la protection des données et de la loi informatique et aux libertés, vous disposez d'un droit d'accès, de rectification, de suppression et d'opposition.</p>
 
         <ul class="fr-mb-5w">
-            <li>Par mail&nbsp;: <a href="mailto:mondiagnosticartificialisation@beta.gouv.fr">mondiagnosticartificialisation@beta.gouv.fr</a></li>
+            <li>Par mail&nbsp;: <a href="mailto:{{ team_email }}">{{ team_email }}</a></li>
             <li>Par voie postale&nbsp;:
                 <blockquote class="bl-highlight">
                     Le Ministère de la Transition écologique et de la Cohésion des territoires<br>

--- a/home/views.py
+++ b/home/views.py
@@ -51,6 +51,10 @@ class LegalNoticeView(BreadCrumbMixin, TemplateView):
 class PrivacyView(BreadCrumbMixin, TemplateView):
     template_name = "home/privacy.html"
 
+    def get_context_data(self, **kwargs):
+        kwargs["team_email"] = app_parameter.TEAM_EMAIL
+        return super().get_context_data(**kwargs)
+
 
 class StatsView(BreadCrumbMixin, TemplateView):
     template_name = "home/stats.html"

--- a/required_parameters.json
+++ b/required_parameters.json
@@ -2,7 +2,7 @@
         "name": "Adresse e-mail de l'équipe",
         "slug": "TEAM_EMAIL",
         "value_type": "STR",
-        "value": "mondiagnosticartificialisation@beta.gouv.fr"
+        "value": "contact@mondiagartif.beta.gouv.fr"
     },
     {
         "name": "Exemple de bilan Andernos",

--- a/scalingo.json
+++ b/scalingo.json
@@ -2,9 +2,9 @@
     "name": "MonDiagArtif",
     "stack": "scalingo-20",
     "description": "Tableau de bord pour mesurer l'artificialisation des sols des collectivités",
-    "logo": "https://mondiagnosticartificialisation.beta.gouv.fr/static/img/logo-mon-diagnostic-artificialisation.svg",
+    "logo": "https://mondiagartif.beta.gouv.fr/static/img/logo-mon-diagnostic-artificialisation.svg",
     "repository": "https://github.com/MTES-MCT/sparte",
-    "website": "https://mondiagnosticartificialisation.beta.gouv.fr/",
+    "website": "https://mondiagartif.beta.gouv.fr/",
     "env": {
         "IS_REVIEW_APP": {
             "description": "flag to know it's a review app",


### PR DESCRIPTION
- [x] Récupérer et gérer les sous-domaines actuels sur AlwaysData: `mondiagnosticartificialisation.beta.gouv.fr`, `sparte-staging.incubateur.net`, `sparte.beta.gouv.fr`
- [x] Créer et récupérer sur AlwaysData le nouveau sous-domaine : `mondiagartif.beta.gouv.fr`
- [x] Créer une nouvelle adresse de contact: `contact@mondiagartif.beta.gouv.fr`
- [x] Créer une redirection des mails reçus sur l'adresse de contact `contact@mondiagartif.beta.gouv.fr` vers les membres de l'équipe ([jeremie.seguin@beta.gouv.fr](mailto:jeremie.seguin@beta.gouv.fr), [nicolas.mouanga@beta.gouv.fr](mailto:nicolas.mouanga@beta.gouv.fr), [ines.dartiguenave@beta.gouv.fr](mailto:ines.dartiguenave@beta.gouv.fr), [philippe.loriot@beta.gouv.fr](mailto:philippe.loriot@beta.gouv.fr))
- [x] Supprimer les mentions en dur des sous-domaines (lien vers le site ou vers le mail) -> Cette PR
- [x] Ajouter `mondiagartif.beta.gouv.fr` sur scalingo
- [x] Configurer le formulaire de contact pour utiliser le nouveau mail: `contact@mondiagartif.beta.gouv.fr` -> A modifier dans l'interface admin

A faire après le merge de cette PR :
- [ ] Ajouter une redirection de `mondiagnosticartificialisation.beta.gouv.fr` -> `mondiagartif.beta.gouv.fr` : PR en draft https://github.com/betagouv/redirections/pull/55
- [ ] Modifier l'url sur dashlord pour pointer sur le nouveau sous-domaine `sparte.beta.gouv.fr` -> `mondiagartif.beta.gouv.fr` PR en draft : https://github.com/betagouv/dashlord/pull/164
- [ ] Remplacer l'alias de `mondiagnosticartificialisation.beta.gouv.fr` `sparte.osc-secnum-fr1.scalingo.io.` 
->  `betagouv-redirections.osc-fr1.scalingo.io.`
- [ ] Créer une redirection des mails reçus sur l'ancien email `mondiagnosticartificialisation@beta.gouv.fr` -> `contact@mondiagartif.beta.gouv.fr`
- [x] Modifier / vérifier les valeurs d'environnement
    - [x] `EMAIL_HOST_USER` 
    - [x] `EMAIL_HOST_PASSWORD`
    - [x] `DEFAULT_FROM_EMAIL`
