### PR TITLE
Supprime fausse erreur dans le connecteur brevo

### DIFF
--- a/brevo/connectors.py
+++ b/brevo/connectors.py
@@ -39,7 +39,7 @@ class Brevo:
     ) -> requests.Response:
         """Send user's data to Brevo."""
         response = requests.post(f"{self.url}/{end_point}", json=data, headers=headers or self.default_headers)
-        if response.status_code != 204:
+        if not response.ok:
             raise BrevoException("Error while sending user's data to Brevo.", response=response)
         return response
 


### PR DESCRIPTION
Certains endpoints retournent d'autres code que `204`(200, 201) donc cette fonction retournait souvent une erreur

`response.ok` retourne `True` si le `status_code` est inférieur à 400

----

Erreur sur sentry: https://sentry.incubateur.net/organizations/betagouv/issues/57855/events/c3f6bf28301b42c0ada8716dbebb8d84/

