### PR TITLE
Changements page artificialisation - Retours datactivist

### DIFF
--- a/project/charts.py
+++ b/project/charts.py
@@ -687,7 +687,7 @@ class DetailCouvArtifChart(ProjectChart):
                 "name": "Artificialisation",
                 "data": [
                     {
-                        "name": item["code_prefix"],
+                        "name": f"{item['code_prefix']} {item['label']}",
                         "y": item["artif"],
                     }
                     for item in self.get_series()
@@ -699,7 +699,7 @@ class DetailCouvArtifChart(ProjectChart):
                 "name": "Renaturation",
                 "data": [
                     {
-                        "name": item["code_prefix"],
+                        "name": f"{item['code_prefix']} {item['label']}",
                         "y": item["renat"],
                     }
                     for item in self.get_series()

--- a/project/templates/project/partials/artif_cities_map.html
+++ b/project/templates/project/partials/artif_cities_map.html
@@ -1,14 +1,14 @@
 <div id="target-artif-cities-map" class="border theme-map-image-container h-100 fr-p-2w d-flex flex-column align-items-center justify-content-between">
-    <div class="d-flex justify-content-end align-items-center w-100 fr-mb-2w">
-        <a href="{% url 'project:theme-city-artif' project.pk %}" target="_blank">
-            <button class="fr-btn fr-icon-external-link-line fr-btn--tertiary fr-btn--sm"></button>
-        </a>
-    </div>
-    <p class="fw-bold">Carte artificialisation des communes du territoire sur la période (en Ha)</p>
-    {% if project.theme_map_artif %}
-    <img src="{{ project.theme_map_artif.url }}" alt="Carte artificialisation des communes du territoire sur la période (en Ha)">
-    {% else %}
-    <div class="skeleton-loader" hx-get="{% url 'project:artif-cities-map' diagnostic.id %}" hx-trigger="load delay:10s" hx-target="#target-artif-cities-map" hx-swap="outerHTML">
-    </div>
-    {% endif %}
+    <a href="{% url 'project:theme-city-artif' project.pk %}" target="_blank">
+        <div class="d-flex justify-content-end align-items-center w-100 fr-mb-2w">
+                <button class="fr-btn fr-icon-external-link-line fr-btn--tertiary fr-btn--sm"></button>
+        </div>
+        <p class="fw-bold">Carte artificialisation des communes du territoire sur la période (en Ha)</p>
+        {% if project.theme_map_artif %}
+        <img src="{{ project.theme_map_artif.url }}" alt="Carte artificialisation des communes du territoire sur la période (en Ha)">
+        {% else %}
+        <div class="skeleton-loader" hx-get="{% url 'project:artif-cities-map' diagnostic.id %}" hx-trigger="load delay:10s" hx-target="#target-artif-cities-map" hx-swap="outerHTML">
+        </div>
+        {% endif %}
+    </a>
 </div>

--- a/project/templates/project/partials/artif_territory_map.html
+++ b/project/templates/project/partials/artif_territory_map.html
@@ -1,15 +1,25 @@
 
 <div id="target-artif-territory-map" class="border theme-map-image-container h-100 fr-p-2w d-flex flex-column align-items-center justify-content-between">
-    <div class="d-flex justify-content-end align-items-center w-100 fr-mb-2w">
-        <a href="{% url 'project:theme-my-artif' project.pk %}" target="_blank">
-             <button class="fr-btn fr-icon-external-link-line fr-btn--tertiary fr-btn--sm"></button>
-        </a>
-    </div>
-    <p class="fw-bold">Carte comprendre l'artificialisation de son territoire</p>
-    {% if project.theme_map_understand_artif %}
-    <img src="{{ project.theme_map_understand_artif.url }}" alt="Carte comprendre l'artificialisation de son territoire">
-    {% else %}
-    <div class="skeleton-loader" hx-get="{% url 'project:artif-territory-map' diagnostic.id %}" hx-trigger="load delay:10s" hx-target="#target-artif-territory-map" hx-swap="outerHTML">
-    </div>
-    {% endif %}
+    <a href="{% url 'project:theme-my-artif' project.pk %}" target="_blank">
+        <div class="d-flex justify-content-end align-items-center w-100 fr-mb-2w">
+            <button class="fr-btn fr-icon-external-link-line fr-btn--tertiary fr-btn--sm"></button>
+        </div>
+        <p class="fw-bold">
+            Carte comprendre l'artificialisation de son territoire
+        </p>
+        {% if project.theme_map_understand_artif %}
+            <img
+                src="{{ project.theme_map_understand_artif.url }}"
+                alt="Carte comprendre l'artificialisation de son territoire"
+            >
+        {% else %}
+            <div
+                class="skeleton-loader"
+                hx-get="{% url 'project:artif-territory-map' diagnostic.id %}"
+                hx-trigger="load delay:10s"
+                hx-target="#target-artif-territory-map"
+                hx-swap="outerHTML">
+            </div>
+        {% endif %}
+    </a>
 </div>

--- a/project/templates/project/report_artif.html
+++ b/project/templates/project/report_artif.html
@@ -33,14 +33,17 @@ Rapport artificialisation
                 </ul>
             </div>
             <div class="fr-callout-read-more__text" id="artif_1" hidden>
-                <p class="fr-text--sm mb-3">L'article 192 de la Loi Climat & Résilience votée en août 2021 définit l'artificialisation comme « une surface dont les sols sont :</p>
+                <p class="fr-text--sm mb-3">
+                    L'article 192 de la Loi Climat & Résilience votée en août 2021 définit
+                    l'artificialisation comme « une surface dont les sols sont :
+                </p>
                 <ul class="fr-text--sm mb-3">
                     <li>soit imperméabilisés en raison du bâti ou d'un revêtement,</li>
                     <li>soit stabilisés et compactés,</li>
                     <li>soit constitués de matériaux composites »</li>
                 </ul>
                 <p class="fr-text--sm mb-3">Elle se traduit dans l'OCS GE nationale comme la somme des  objets anthropisés dans la description de la couverture des sols.</p>
-                <p class="fr-text--sm mb-3">L'application applique ici un croisement des données de l'OCS GE pour définir l'artificialisation conformément aux attendus de la loi Climat & Résilience, et au décret « nomenclature de l'artificialisation des sols» <small>(Décret n° 2022-763 du 29 avril 2022 relatif à la nomenclature de l'artificialisation des sols pour la fixation et le suivi des objectifs dans les documents de planification et d'urbanisme)</small>.</p>
+                <p class="fr-text--sm mb-3">L'application applique ici un croisement des données de l'OCS GE pour définir l'artificialisation conformément aux attendus de la loi Climat & Résilience, et au décret « nomenclature de l'artificialisation des sols» <a rel="noopener noreferrer" target="_blank" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045727061">(Décret n° 2022-763 du 29 avril 2022 relatif à la nomenclature de l'artificialisation des sols pour la fixation et le suivi des objectifs dans les documents de planification et d'urbanisme)</a>.</p>
                 <p class="fr-text--sm mb-3"><strong>Définition de l'artificialisation des sols</strong></p>
                 <p class="fr-text--sm mb-3">La nomenclature précise que les surfaces dont les sols sont soit imperméabilisés en raison du bâti ou d'un revêtement, soit stabilisés et compactés, soit constitués de matériaux composites sont qualifiées de surfaces artificialisées. De même, les surfaces végétalisées herbacées (c'est-à-dire non ligneuses) et qui sont à usage résidentiel, de production secondaire ou tertiaire, ou d'infrastructures, sont considérées comme artificialisées, y compris lorsqu'elles sont en chantier ou à l'état d'abandon.</p>
                 <p class="fr-text--sm mb-3">L'artificialisation nette est définie comme « le solde de l'artificialisation et de la renaturation des sols constatées sur un périmètre et sur une période donnés » (article L.101-2-1 du code de l'urbanisme). </p>
@@ -56,6 +59,9 @@ Rapport artificialisation
         <div class="fr-mt-12w">
 
             <h2>Etat des lieux du territoire au dernier millésime</h2>
+            <a class="fr-link" href="{% url 'documentation:faq' %}#accordion-4">
+                Qu'est-ce qu'un millésime ?
+            </a>
 
             <div class="fr-mt-7w">
                 <div class="fr-grid-row fr-grid-row--gutters">
@@ -69,9 +75,9 @@ Rapport artificialisation
                         <div class="fr-callout w-100">
                         <p class="fr-callout__title">{{ artif_area|floatformat:0 }} ha</p>
                         <p>
-                            <span 
-                                class="dotted" 
-                                data-toggle="tooltip" 
+                            <span
+                                class="dotted"
+                                data-toggle="tooltip"
                                 title="Surfaces répondant à la définition de la loi Climat et Résilience et à ses décrets d'application en {{ last_millesime }}"
                                 aria-hidden="true">
                                 Surfaces artificialisées
@@ -583,6 +589,7 @@ Rapport artificialisation
                 <p class="fr-text--sm">Avec le bouton <span class="fr-icon-drag-move-2-line fr-icon--sm" aria-hidden="true"></span>, vous pouvez afficher le graphique en plein écran.</p>
                 <p class="fr-text--sm">Avec le bouton <span class="fr-icon-download-line fr-icon--sm" aria-hidden="true"></span>, vous pouvez télécharger le graphique sous forme d'image (utilisez PNG si vous ne savez pas lequel choisir).</p>
                 <p class="fr-text--sm">Exemple de lecture: 8% des nouvelles surfaces artificialisés le sont pour des Zones bâties.</p>
+                <p class="fr-text--sm">Vous pouvez analyser la répartition des surfaces artificialisées sur la période en pourcentage avec le camembert, ou en volume au dernier millésime avec l'histogramme.</p>
             </div>
         </div>
     </div>
@@ -603,6 +610,7 @@ Rapport artificialisation
                 <p class="fr-text--sm">Avec le bouton <span class="fr-icon-drag-move-2-line fr-icon--sm" aria-hidden="true"></span>, vous pouvez afficher le graphique en plein écran.</p>
                 <p class="fr-text--sm">Avec le bouton <span class="fr-icon-download-line fr-icon--sm" aria-hidden="true"></span>, vous pouvez télécharger le graphique sous forme d'image (utilisez PNG si vous ne savez pas lequel choisir).</p>
                 <p class="fr-text--sm">Exemple de lecture: 55% des nouvelles surfaces artificialisées le sont pour des Zones résidentielles.</p>
+                <p class="fr-text--sm">Vous pouvez analyser la répartition des surfaces artificialisées sur la période en pourcentage avec le camembert, ou en volume au dernier millésime avec l'histogramme.</p>
             </div>
         </div>
     </div>

--- a/project/views/map.py
+++ b/project/views/map.py
@@ -1029,6 +1029,7 @@ class MyArtifMapView(BaseMap):
         return super().get_sources_list(*(additional_sources + list(sources)))
 
     def get_layers_list(self, *layers):
+        available_millesimes = self.object.get_available_millesimes()
         additional_layers = [
             {
                 "id": "zones-artificielles-fill-layer",
@@ -1105,6 +1106,10 @@ class MyArtifMapView(BaseMap):
                         {
                             "value": "Renaturation",
                             "color": "#43d360",
+                        },
+                        {
+                            "value": f"Surfaces artificialisées ({available_millesimes[-1]})",  # Last year
+                            "color": "#F88E55",
                         },
                     ],
                 },


### PR DESCRIPTION
US : https://app.clickup.com/t/8693u4e33

----

- [x] Ajouter lien vers le décret

avant
<img width="1195" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/1b8df431-4b29-4dc7-8b80-bfdea4a3b532">

après
<img width="1199" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/a0b56d68-bb2e-4048-8560-e1ef8eb35509">

- [x] Ajouter lien FAQ explication millésime

avant
<img width="1226" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/1010a35e-6c79-40a6-87c7-2500d4cab448">

après
<img width="1230" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/3585d2f6-16eb-443b-bbe1-df72b8dc385d">

- [x] Rendre "Carte comprendre l'artificialisation de son territoire" clickable

- [x] Définir zone orange dans la légende + utiliser "Artificialisation / Renaturation" pour flux et "surface artificialisée" pour stock
avant
<img width="161" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/51fbb150-45a8-4938-9151-9f2afd0a22fe">

après
<img width="219" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/a98f319a-500a-45f6-b50d-1e4bdc0f6bb0">

- [x] Histogramme évolution des surface artificielles -> expliquer les codes CS et US en bas
couverture
avant
<img width="812" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/b2e5fc62-e34a-4f02-8da5-1eb2123c0365">

après
<img width="818" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/ecf21a37-c99f-461b-91fe-20dcd8e86c2f">

usage

avant
<img width="809" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/541515ea-940b-4600-9e59-38b27f9925f4">

après
<img width="805" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/3ec5dc11-676c-4680-9677-ae033a8620ce">

- [x] Astuce de lecture Grandes familles d'usage des sols

avant
<img width="519" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/2bff3102-e368-405f-b85f-cd33b165f204">

après
<img width="520" alt="image" src="https://github.com/MTES-MCT/sparte/assets/16051000/3a2ca39d-70e7-413d-baec-4757cd462e5a">




