### PR TITLE
Fix commande de MEP V5.0

### DIFF
--- a/public_data/management/commands/mep_47.py
+++ b/public_data/management/commands/mep_47.py
@@ -37,6 +37,10 @@ class Command(BaseCommand):
         call_command("maintenance", on=True)
 
         logger.info("Initialize data sources")
+        # Since we are editing the data sources for Gers, we need to delete them first,
+        # otherwise we will have duplicates for that departement
+        deleted, _ = DataSource.objects.all().delete()
+        logger.info(f"Deleted {deleted} data sources")
         call_command("loaddata", "public_data/models/data_source_fixture.json")
 
         logger.info("Load new OCS GE")

--- a/public_data/management/commands/mep_5.py
+++ b/public_data/management/commands/mep_5.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("management.commands")
 
 
 class Command(BaseCommand):
-    help = "Dedicated to load data for 4.7 deployment"
+    help = "Dedicated to load data for 5.0 deployment"
 
     def load_departement(self, departement: Departement):
         call_command(
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        logger.info("Start mep_47")
+        logger.info("Start mep_5")
 
         call_command("maintenance", on=True)
 
@@ -62,4 +62,4 @@ class Command(BaseCommand):
             self.load_departement(departement)
 
         call_command("maintenance", off=True)
-        logger.info("End mep_47")
+        logger.info("End mep_5")


### PR DESCRIPTION
Supprime les `DataSource` avant de les charger afin d'éviter un conflit avec les sources existantes pour les gers, et celles nouvellement chargées.