### PR TITLE
Suppression warning slugignore des builds de container sur scalingo

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,2 @@
-notebooks
 assets/scripts
 assets/styles


### PR DESCRIPTION
Supprime ce warning :

![image](https://github.com/MTES-MCT/sparte/assets/16051000/747fba98-35b3-4259-8625-cc4f509b24a2)
