### PR TITLE
Remplace l'histogramme de conso annuelle par un diagramme en bar

### DIFF
--- a/project/views/report.py
+++ b/project/views/report.py
@@ -66,7 +66,7 @@ class ProjectReportConsoView(ProjectReportBaseView):
         level = self.request.GET.get("level_conso", project.level)
 
         # communes_data_graph
-        chart_conso_cities = charts.AnnualConsoChart(project, level=level)
+        chart_conso_cities = charts.AnnualTotalConsoChart(project, level=level)
 
         target_2031_consumption = project.get_bilan_conso()
         current_conso = project.get_bilan_conso_time_scoped()
@@ -165,7 +165,7 @@ class ProjectReportCityGroupView(ProjectReportBaseView):
             return set(_.name for _ in group if _.name is not None)
 
         # Consommation des communes
-        chart_conso_cities = charts.AnnualConsoChart(project, group_name=group_name)
+        chart_conso_cities = charts.AnnualTotalConsoChart(project, group_name=group_name)
         communes_table = dict()
         for city_name, data in chart_conso_cities.get_series().items():
             data.update({"Total": sum(data.values())})


### PR DESCRIPTION
Avant (auch)
![image](https://github.com/MTES-MCT/sparte/assets/16051000/dba959f0-f879-43fa-8910-74717695ed97)

Après (auch)
![image](https://github.com/MTES-MCT/sparte/assets/16051000/b9446ed0-28e8-45c4-a6dc-4396f81a701e)


Avant (CA Grand Auch Cœur de Gascogne)
![image](https://github.com/MTES-MCT/sparte/assets/16051000/aa1e083c-abda-4259-b05d-1a6c0461fc84)

Après (CA Grand Auch Cœur de Gascogne)
![image](https://github.com/MTES-MCT/sparte/assets/16051000/2f6c4866-b767-45a0-aa7c-9937b9d70534)

