### PR TITLE
Bump postgres to 14.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: kartoza/postgis:13-3.1--v2021.09.08
+    image: kartoza/postgis:14-3.3--v2022.08.30
     shm_size: 1gb
     volumes:
       - db_data:/var/lib/postgresql/data


### PR DESCRIPTION
Pas exactement iso avec la prod, mais c'est le plus proche que kartoza a publié.
https://hub.docker.com/layers/kartoza/postgis/14-3.3--v2022.08.30/images/sha256-d0614c910daddc0012a9a1b7be05383cdd96bcb49de60edb7474869073a5919e?context=explore

Fix #199 