### PR TITLE
Inversion de la logique de réduction du graphique / tableau trajectoire

### DIFF
--- a/diagnostic_word/renderers.py
+++ b/diagnostic_word/renderers.py
@@ -224,8 +224,8 @@ class BaseRenderer:
             "chart_determinants": self.prep_chart(det_chart),
             "pie_chart_determinants": self.prep_chart(pie_det_chart),
             "projection_zan_2031": self.prep_chart(objective_chart),
-            "projection_zan_cumulee_ref": round(objective_chart.total_real, 1),
-            "projection_zan_annuelle_ref": round(objective_chart.annual_real, 1),
+            "projection_zan_cumulee_ref": round(objective_chart.total_2020, 1),
+            "projection_zan_annuelle_ref": round(objective_chart.annual_2020, 1),
             "projection_zan_cumulee_objectif": round(objective_chart.conso_2031),
             "projection_zan_annuelle_objectif": round(objective_chart.annual_objective_2031),
         }

--- a/project/charts/ObjectiveChart.py
+++ b/project/charts/ObjectiveChart.py
@@ -99,7 +99,8 @@ class ObjectiveChart(ProjectChart):
                 "zIndex": 1,
             },
         ]
-        self.total_real = self.total_2020 = 0
+        self.total_real = 0
+        self.total_2020 = 0
         for year, val in self.project.land.get_conso_per_year(
             start="2011",
             end="2022",
@@ -117,7 +118,7 @@ class ObjectiveChart(ProjectChart):
             self.series[0]["data"].append({"name": year, "y": val})
 
         self.annual_2020 = self.total_2020 / 10
-        self.annual_objective_2031 = self.total_2020 * self.project.target_2031 / 1000
+        self.annual_objective_2031 = self.annual_2020 - (self.annual_2020 / 100 * self.project.target_2031)
         self.annual_real = self.total_real / 10
         self.total_2031 = self.total_2020
         self.conso_2031 = self.annual_objective_2031 * 10

--- a/project/templates/project/partials/report_target_2031_graphic.html
+++ b/project/templates/project/partials/report_target_2031_graphic.html
@@ -94,8 +94,8 @@
 
 {% if reload_kpi %}
     <span id="objective-swapper" hx-swap-oob="true">{{ diagnostic.target_2031 }}</span>
-    <span id="total_real-swapper" hx-swap-oob="true">{{ total_real|floatformat:1 }}</span>
-    <span id="annual_real-swapper" hx-swap-oob="true">{{ annual_real|floatformat:1 }}</span>
+    <span id="total_real-swapper" hx-swap-oob="true">{{ total_2020|floatformat:1 }}</span>
+    <span id="annual_real-swapper" hx-swap-oob="true">{{ annual_2020|floatformat:1 }}</span>
     <span id="conso_2031-swapper" hx-swap-oob="true">{{ conso_2031|floatformat:1 }}</span>
     <span id="annual_objective-swapper" hx-swap-oob="true">{{ annual_objective_2031|floatformat:1 }}</span>
 {% endif %}

--- a/project/views/report.py
+++ b/project/views/report.py
@@ -536,8 +536,8 @@ class ProjectReportTarget2031GraphView(ProjectReportBaseView):
                 "reload_kpi": True,
                 "diagnostic": diagnostic,
                 "target_2031_chart": target_2031_chart,
-                "total_real": target_2031_chart.total_real,
-                "annual_real": target_2031_chart.annual_real,
+                "total_2020": target_2031_chart.total_2020,
+                "annual_2020": target_2031_chart.annual_2020,
                 "conso_2031": target_2031_chart.conso_2031,
                 "annual_objective_2031": target_2031_chart.annual_objective_2031,
             }


### PR DESCRIPTION
Avant : 
- valeur de 10% retournait 10% du total de consommation sur la période de référence comme valeur de "droit à consommer"

Après : 
- valeur de 10% retourne 90% du total de consommation sur la période de référence comme valeur de "droit à consommer" (réduction de 10%)

-----

La PR corrige également un bug : lors du rechargement de la valeur de réduction par HTMX, le total de la période de référence était éronné, le total de la conso sur la période du diagnostic était affiché au lieu du total de la période de référence.

---- 

Testable ici : https://sparte-staging-pr371.osc-fr1.scalingo.io/