### PR TITLE
Reduction de la taille des images des diagnostics

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -213,7 +213,7 @@ AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="eu-west-3")
 # append a prefix to all uploaded file (useful to not mix local, staging...)
 AWS_LOCATION = env.str("AWS_LOCATION", default="local")
 # avoid overriding a file if same key is provided
-AWS_S3_FILE_OVERWRITE = False
+AWS_S3_FILE_OVERWRITE = True
 # allow signed url to be accessed from all regions
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 

--- a/config/storages.py
+++ b/config/storages.py
@@ -10,5 +10,4 @@ class PublicMediaStorage(S3Boto3Storage):
 
     location = "media"
     default_acl = "public-read"
-    file_overwrite = False
     querystring_auth = False

--- a/project/admin.py
+++ b/project/admin.py
@@ -20,6 +20,11 @@ class ProjectAdmin(SimpleHistoryAdmin):
         "analyse_start_date",
         "analyse_end_date",
     )
+    readonly_fields = (
+        "cities",
+        "async_complete",
+        "is_ready_to_be_displayed",
+    )
     search_fields = (
         "name",
         "user__email",

--- a/project/models/create.py
+++ b/project/models/create.py
@@ -1,4 +1,3 @@
-from types import ModuleType
 from typing import List
 
 import celery
@@ -10,25 +9,38 @@ from public_data.models import AdminRef, Land
 from users.models import User
 
 
-def get_map_generation_tasks(project: Project, t: ModuleType) -> List[celery.Task]:
+@celery.shared_task  # noqa: C901
+def map_tasks(project_id: str) -> List[celery.Task]:  # noqa: C901
     """Return a list of tasks to generate maps according to project state"""
+
+    project = Project.objects.get(id=project_id)
 
     map_tasks = []
 
+    not_a_commune = project.land_type != AdminRef.COMMUNE
+
     if not project.async_cover_image_done:
         map_tasks.append(tasks.generate_cover_image.si(project.id))
-    if not project.async_generate_theme_map_conso_done and project.land_type != AdminRef.COMMUNE:
-        map_tasks.append(tasks.generate_theme_map_conso.si(project.id))
-    if not project.async_generate_theme_map_artif_done and project.land_type != AdminRef.COMMUNE:
-        map_tasks.append(tasks.generate_theme_map_artif.si(project.id))
-    if not project.async_theme_map_understand_artif_done:
-        map_tasks.append(tasks.generate_theme_map_understand_artif.si(project.id))
-    if not project.async_theme_map_gpu_done:
-        map_tasks.append(tasks.generate_theme_map_gpu.si(project.id))
-    if not project.async_theme_map_fill_gpu_done:
-        map_tasks.append(tasks.generate_theme_map_fill_gpu.si(project.id))
 
-    return map_tasks
+    if not_a_commune:
+        if not project.async_generate_theme_map_conso_done:
+            map_tasks.append(tasks.generate_theme_map_conso.si(project.id))
+
+    if not_a_commune and project.has_complete_uniform_ocsge_coverage:
+        if not project.async_generate_theme_map_artif_done:
+            map_tasks.append(tasks.generate_theme_map_artif.si(project.id))
+
+    if project.has_complete_uniform_ocsge_coverage:
+        if not project.async_theme_map_understand_artif_done:
+            map_tasks.append(tasks.generate_theme_map_understand_artif.si(project.id))
+
+    if project.has_complete_uniform_ocsge_coverage and project.has_zonage_urbanisme:
+        if not project.async_theme_map_gpu_done:
+            map_tasks.append(tasks.generate_theme_map_gpu.si(project.id))
+        if not project.async_theme_map_fill_gpu_done:
+            map_tasks.append(tasks.generate_theme_map_fill_gpu.si(project.id))
+
+    celery.group(*map_tasks, immutable=True).apply_async()
 
 
 def trigger_async_tasks(project: Project, public_key: str | None = None) -> None:
@@ -36,37 +48,32 @@ def trigger_async_tasks(project: Project, public_key: str | None = None) -> None
     from metabase.tasks import async_create_stat_for_project
     from project import tasks as t
 
-    tasks_chain = []
+    before_calculations = []
+
     if not project.async_add_city_done:
-        if public_key is None:
-            raise ValueError("Cannot add_cities to project without public_key.")
-        tasks_chain.append(t.add_city.si(project.id, public_key))
+        before_calculations.append(t.add_city.si(project.id, public_key))
     if not project.async_set_combined_emprise_done:
-        tasks_chain.append(t.set_combined_emprise.si(project.id))
+        before_calculations.append(t.set_combined_emprise.si(project.id))
 
-    group_1 = []
+    calculations = []
+
     if not project.async_find_first_and_last_ocsge_done:
-        group_1.append(t.find_first_and_last_ocsge.si(project.id))
+        calculations.append(t.find_first_and_last_ocsge.si(project.id))
     if not project.async_ocsge_coverage_status_done:
-        group_1.append(t.calculate_project_ocsge_status.si(project.id))
+        calculations.append(t.calculate_project_ocsge_status.si(project.id))
     if not project.async_add_comparison_lands_done:
-        group_1.append(t.add_comparison_lands.si(project.id))
-    if group_1:
-        tasks_chain.append(celery.group(*group_1))
+        calculations.append(t.add_comparison_lands.si(project.id))
 
-    map_group = get_map_generation_tasks(project, t)
-    if map_group:
-        tasks_chain.append(celery.group(*map_group))
-
-    # Exécution de la chaîne
-    if tasks_chain:
-        celery.chain(
-            *tasks_chain,
-            celery.group(
-                async_create_stat_for_project.si(project.id, do_location=True),
-                send_diagnostic_to_brevo.si(project.id),
-            ),
-        ).apply_async()
+    return celery.chain(
+        *before_calculations,
+        celery.group(*calculations, immutable=True),
+        map_tasks.si(project.id),
+        celery.group(
+            async_create_stat_for_project.si(project.id, do_location=True),
+            send_diagnostic_to_brevo.si(project.id),
+            immutable=True,
+        ),
+    )()
 
 
 def create_from_public_key(

--- a/project/models/project_base.py
+++ b/project/models/project_base.py
@@ -417,7 +417,22 @@ class Project(BaseProject):
         return latest_change.history_change_reason == ProjectChangeReason.NEW_OCSGE_HAS_BEEN_DELIVERED
 
     @property
-    def async_complete(self):
+    def __async_complete_commune(self) -> bool:
+        return (
+            self.async_add_city_done
+            & self.async_set_combined_emprise_done
+            & self.async_cover_image_done
+            & self.async_find_first_and_last_ocsge_done
+            & self.async_ocsge_coverage_status_done
+            & self.async_add_comparison_lands_done
+            & self.async_theme_map_understand_artif_done
+        )
+
+    @property
+    def async_complete(self) -> bool:
+        if self.land_type == AdminRef.COMMUNE:
+            return self.__async_complete_commune
+
         return (
             self.async_add_city_done
             & self.async_set_combined_emprise_done
@@ -437,6 +452,7 @@ class Project(BaseProject):
             & self.async_set_combined_emprise_done
             & self.async_add_comparison_lands_done
             & self.async_find_first_and_last_ocsge_done
+            & self.async_ocsge_coverage_status_done
         )
 
     class Meta:

--- a/project/models/project_base.py
+++ b/project/models/project_base.py
@@ -417,42 +417,47 @@ class Project(BaseProject):
         return latest_change.history_change_reason == ProjectChangeReason.NEW_OCSGE_HAS_BEEN_DELIVERED
 
     @property
-    def __async_complete_commune(self) -> bool:
-        return (
-            self.async_add_city_done
-            & self.async_set_combined_emprise_done
-            & self.async_cover_image_done
-            & self.async_find_first_and_last_ocsge_done
-            & self.async_ocsge_coverage_status_done
-            & self.async_add_comparison_lands_done
-            & self.async_theme_map_understand_artif_done
-        )
-
-    @property
     def async_complete(self) -> bool:
-        if self.land_type == AdminRef.COMMUNE:
-            return self.__async_complete_commune
-
-        return (
+        calculations_and_extend_ready = (
             self.async_add_city_done
-            & self.async_set_combined_emprise_done
-            & self.async_cover_image_done
-            & self.async_find_first_and_last_ocsge_done
-            & self.async_ocsge_coverage_status_done
-            & self.async_add_comparison_lands_done
-            & self.async_generate_theme_map_conso_done
-            & self.async_generate_theme_map_artif_done
-            & self.async_theme_map_understand_artif_done
+            and self.async_set_combined_emprise_done
+            and self.async_cover_image_done
+            and self.async_find_first_and_last_ocsge_done
+            and self.async_ocsge_coverage_status_done
+            and self.async_add_comparison_lands_done
         )
+
+        static_maps_ready = self.async_cover_image_done
+
+        not_a_commune = self.land_type != AdminRef.COMMUNE
+
+        # logic below is duplicated from map_tasks in create.py
+        # TODO : refactor this
+
+        if not_a_commune:
+            static_maps_ready = static_maps_ready and self.async_generate_theme_map_conso_done
+
+        if not_a_commune and self.has_complete_uniform_ocsge_coverage:
+            static_maps_ready = static_maps_ready and self.async_generate_theme_map_artif_done
+
+        if self.has_complete_uniform_ocsge_coverage:
+            static_maps_ready = static_maps_ready and self.async_theme_map_understand_artif_done
+
+        if self.has_zonage_urbanisme and self.has_complete_uniform_ocsge_coverage:
+            static_maps_ready = (
+                static_maps_ready and self.async_theme_map_gpu_done and self.async_theme_map_fill_gpu_done
+            )
+
+        return calculations_and_extend_ready and static_maps_ready
 
     @property
     def is_ready_to_be_displayed(self) -> bool:
         return (
             self.async_add_city_done
-            & self.async_set_combined_emprise_done
-            & self.async_add_comparison_lands_done
-            & self.async_find_first_and_last_ocsge_done
-            & self.async_ocsge_coverage_status_done
+            and self.async_set_combined_emprise_done
+            and self.async_add_comparison_lands_done
+            and self.async_find_first_and_last_ocsge_done
+            and self.async_ocsge_coverage_status_done
         )
 
     class Meta:

--- a/project/tasks/project.py
+++ b/project/tasks/project.py
@@ -248,7 +248,11 @@ def generate_cover_image(self, project_id):
         cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL)
 
         img_data = io.BytesIO()
-        plt.savefig(img_data, bbox_inches="tight")
+        plt.savefig(
+            img_data,
+            bbox_inches="tight",
+            format="jpg",
+        )
         img_data.seek(0)
         plt.close()
 
@@ -256,7 +260,7 @@ def generate_cover_image(self, project_id):
             diagnostic.pk,
             "async_cover_image_done",
             "cover_image",
-            f"cover_{project_id}.png",
+            f"cover_{project_id}.jpg",
             img_data,
         )
 
@@ -397,7 +401,7 @@ def get_img(queryset, color: str, title: str) -> io.BytesIO:
 
     fig, ax = plt.subplots(figsize=(15, 10))
     plt.axis("off")
-    fig.set_dpi(150)
+    fig.set_dpi(100)
 
     gdf.plot(
         "level",
@@ -412,7 +416,7 @@ def get_img(queryset, color: str, title: str) -> io.BytesIO:
     )
     ax.add_artist(ScaleBar(1))
     ax.set_title(title)
-    cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL)
+    cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL, zoom_adjust=1, alpha=0.95)
 
     img_data = io.BytesIO()
     plt.savefig(img_data, bbox_inches="tight")

--- a/project/tasks/project.py
+++ b/project/tasks/project.py
@@ -419,7 +419,7 @@ def get_img(queryset, color: str, title: str) -> io.BytesIO:
     cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL, zoom_adjust=1, alpha=0.95)
 
     img_data = io.BytesIO()
-    plt.savefig(img_data, bbox_inches="tight")
+    plt.savefig(img_data, bbox_inches="tight", format="jpg")
     img_data.seek(0)
     plt.close()
     return img_data
@@ -447,7 +447,7 @@ def generate_theme_map_conso(self, project_id):
             diagnostic.pk,
             "async_generate_theme_map_conso_done",
             "theme_map_conso",
-            f"theme_map_conso_{project_id}.png",
+            f"theme_map_conso_{project_id}.jpg",
             img_data,
         )
 
@@ -481,7 +481,7 @@ def generate_theme_map_artif(self, project_id):
             diagnostic.pk,
             "async_generate_theme_map_artif_done",
             "theme_map_artif",
-            f"theme_map_artif_{project_id}.png",
+            f"theme_map_artif_{project_id}.jpg",
             img_data,
         )
 
@@ -578,14 +578,14 @@ def generate_theme_map_understand_artif(self, project_id):
         cx.add_attribution(ax, text="Données: OCS GE (IGN)")
 
         img_data = io.BytesIO()
-        plt.savefig(img_data, bbox_inches="tight")
+        plt.savefig(img_data, bbox_inches="tight", format="jpg")
         img_data.seek(0)
 
         race_protection_save_map(
             diagnostic.pk,
             "async_theme_map_understand_artif_done",
             "theme_map_understand_artif",
-            f"theme_map_understand_artif_{project_id}.png",
+            f"theme_map_understand_artif_{project_id}.jpg",
             img_data,
         )
 
@@ -633,7 +633,7 @@ def generate_theme_map_gpu(self, project_id):
         cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL)
 
         img_data = io.BytesIO()
-        plt.savefig(img_data, bbox_inches="tight")
+        plt.savefig(img_data, bbox_inches="tight", format="jpg")
         plt.close()
         img_data.seek(0)
 
@@ -641,7 +641,7 @@ def generate_theme_map_gpu(self, project_id):
             diagnostic.pk,
             "async_theme_map_gpu_done",
             "theme_map_gpu",
-            f"theme_map_gpu_{project_id}.png",
+            f"theme_map_gpu_{project_id}.jpg",
             img_data,
         )
 
@@ -692,7 +692,7 @@ def generate_theme_map_fill_gpu(self, project_id):
             cx.add_basemap(ax, source=settings.ORTHOPHOTO_URL)
 
             img_data = io.BytesIO()
-            plt.savefig(img_data, bbox_inches="tight")
+            plt.savefig(img_data, bbox_inches="tight", format="jpg")
             plt.close()
             img_data.seek(0)
 
@@ -700,7 +700,7 @@ def generate_theme_map_fill_gpu(self, project_id):
             diagnostic.pk,
             "async_theme_map_fill_gpu_done",
             "theme_map_fill_gpu",
-            f"theme_map_fill_gpu_{project_id}.png",
+            f"theme_map_fill_gpu_{project_id}.jpg",
             img_data,
         )
 

--- a/public_data/management/commands/build_shapefile.py
+++ b/public_data/management/commands/build_shapefile.py
@@ -26,7 +26,6 @@ def upload_file_to_s3(path: Path):
 
     with open(path, "b+r") as f:
         storage = DataStorage()
-        storage.file_overwrite = True
         storage.save(path.name, f)
 
     logger.info(f"Uploaded {path.name} to S3")

--- a/public_data/management/commands/export_gpu.py
+++ b/public_data/management/commands/export_gpu.py
@@ -53,7 +53,6 @@ class Command(BaseCommand):
         logger.info("Export GPU to csv on s3")
 
         self.storage = DataStorage()
-        self.storage.file_overwrite = True
 
         qs = Departement.objects.all().order_by("name")
 

--- a/public_data/storages.py
+++ b/public_data/storages.py
@@ -7,4 +7,3 @@ class DataStorage(S3Boto3Storage):
 
     bucket_name = settings.AWS_STORAGE_BUCKET_NAME
     location = "data"
-    file_overwrite = False


### PR DESCRIPTION
- Pour les communes : arrêt de la génération des fichiers
    -`theme_map_conso` 1,25mo
    -`theme_map_artif`  1,25mo
- Pour les territoires sans OCS GE, arrêt de la générations des fichiers :
    - `theme_map_understand_artif` 1.57mo
    - `theme_map_gpu` 1.21mo
    - `theme_map_fill_gpu` 1.19mo
- Pour les territoires sans GPU, arrêt de la générations des fichiers :
    - `theme_map_gpu` 1.21mo
    - `theme_map_fill_gpu` 1.19mo
- Amélioration de la qualité de l'image de couverture (en demandant au WMTS un niveau de zoom supérieur).
- Passage des images utilisant de l'orthophoto du format png au format jpg (plus efficace pour des images type raster):
    - `cover` : 1.25mo -> 130.27 Ko
    - `theme_map_fill_gpu`: 1.19mo -> 141ko
    - `theme_map_gpu`: 1.21mo -> 148ko
    - `theme_map_understand_artif`: 1.57mo -> 200ko
    - `theme_map_artif`: 1.25mo -> 188ko
    - `theme_map_conso`: 1.25mo -> 188ko
    
    
-----
    
 Exemple de réduction totale : 
 - Auch: 7.7mo -> 620ko
 - Nantes (sans OCSGE):  7.7mo -> 130ko
    