### PR TITLE
Corriger le titre du graphique répartition de l'usage des sols

### DIFF
--- a/project/charts/UsagePieChart.py
+++ b/project/charts/UsagePieChart.py
@@ -8,6 +8,14 @@ class UsagePieChart(CouverturePieChart):
     _level = 1
     _sol = "usage"
 
+    @property
+    def param(self):
+        return super().param | {
+            "title": {
+                "text": f"Répartition de l'usage des sols en {self.project.last_year_ocsge}",
+            },
+        }
+
 
 class UsagePieChartExport(UsagePieChart):
     def get_series_item_name(self, item: CouvertureSol | UsageSol) -> str:


### PR DESCRIPTION
Corriger le titre du graphique répartition de l'usage des sols. 
Titre actuel: Répartition de la couverture des sols en {project.last_year_oscge}
Titre souhaité: Répartition de l'usage des sols  en {project.last_year_oscge}

Avant:
<img width="637" alt="Capture d’écran 2024-06-18 à 10 40 35" src="https://github.com/MTES-MCT/sparte/assets/16525551/a9e49d88-8c9b-471b-b139-4af69db55445">

Après:
<img width="636" alt="Capture d’écran 2024-06-18 à 10 40 14" src="https://github.com/MTES-MCT/sparte/assets/16525551/75827f3f-4986-4595-919a-60dd89390229">
