### PR TITLE
Supprime les carrières de l'artif

### DIFF
--- a/public_data/domain/artificialisation/use_case/CalculateCommuneArtificialAreas.py
+++ b/public_data/domain/artificialisation/use_case/CalculateCommuneArtificialAreas.py
@@ -1,0 +1,44 @@
+from logging import getLogger
+
+from django.contrib.gis.db.models import Union
+from django.contrib.gis.db.models.functions import Area, Intersection, MakeValid
+from django.db.models import Sum
+
+from public_data.models.administration import Commune
+from public_data.models.ocsge import ArtificialArea, Ocsge
+from utils.db import DynamicSRIDTransform, fix_poly
+
+logger = getLogger(__name__)
+
+
+class CalculateCommuneArtificialAreas:
+    @staticmethod
+    def execute(commune: Commune):
+        qs = Ocsge.objects.filter(
+            mpoly__intersects=commune.mpoly,
+            is_artificial=True,
+            departement=commune.departement.source_id,
+        )
+        if not qs.exists():
+            return
+
+        qs = (
+            qs.annotate(intersection=Intersection(MakeValid("mpoly"), commune.mpoly))
+            .annotate(intersection_area=Area(DynamicSRIDTransform("intersection", "srid_source")))
+            .values("year")
+            .annotate(geom=MakeValid(Union("intersection")), surface=Sum("intersection_area"))
+        )
+
+        for result in qs:
+            ArtificialArea.objects.update_or_create(
+                city=commune.insee,
+                year=result["year"],
+                defaults={
+                    "mpoly": fix_poly(result["geom"]),
+                    "surface": result["surface"].sq_m / 10000,
+                    "departement": commune.departement.source_id,
+                    "srid_source": commune.srid_source,
+                },
+            )
+
+        return ArtificialArea.objects.filter(city=commune.insee)

--- a/public_data/management/commands/build_shapefile.py
+++ b/public_data/management/commands/build_shapefile.py
@@ -36,8 +36,7 @@ def is_artif_case(code_cs: str, code_us: str) -> str:
         /* CS 1.1 */
         WHEN {code_cs} = 'CS1.1.1.1' THEN 1
         WHEN {code_cs} = 'CS1.1.1.2' THEN 1
-        WHEN {code_cs} = 'CS1.1.1.1' AND {code_us} != 'US1.3' THEN 1
-        WHEN {code_cs} = 'CS1.1.2.1' THEN 1
+        WHEN {code_cs} = 'CS1.1.2.1' AND {code_us} != 'US1.3' THEN 1
         WHEN {code_cs} = 'CS1.1.2.2' THEN 1
 
         /* CS 2.2 */
@@ -599,7 +598,6 @@ class Command(BaseCommand):
         sources = DataSource.objects.filter(
             dataset=options.get("dataset"),
             productor=options.get("productor"),
-            millesimes__overlap=options.get("millesimes"),
         )
         if options.get("land_id"):
             sources = sources.filter(official_land_id=options.get("land_id"))

--- a/public_data/management/commands/fix_is_artif_carriere.py
+++ b/public_data/management/commands/fix_is_artif_carriere.py
@@ -1,0 +1,44 @@
+import logging
+
+import celery
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from public_data.models import Commune, Ocsge
+from public_data.tasks import calculate_commune_artificial_area
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Fix is_artif_carriere"
+
+    def handle(self, *args, **options):
+        call_command(command_name="load_shapefile", dataset="OCSGE", name="DIFFERENCE")
+
+        ocsge_with_carriere = Ocsge.objects.filter(
+            couverture="CS1.1.2.1",  # zones à matériaux minéraux,
+            usage="US1.3",  # activité d'extraction
+        )
+
+        ocsge_with_carriere.update(
+            is_artificial=False,
+        )
+
+        communes = Commune.objects.filter(
+            ocsge_available=True,
+        )
+
+        celery_tasks = []
+
+        for commune in communes:
+            ocsge_with_carriere_on_commune = ocsge_with_carriere.filter(
+                mpoly__intersects=commune.mpoly,
+            )
+
+            if ocsge_with_carriere_on_commune.exists():
+                logger.info(f"Commune {commune.insee} has carriere")
+                celery_tasks.append(calculate_commune_artificial_area.si(commune.insee))
+        logger.info(f"Found {len(celery_tasks)} communes with carriere")
+
+        celery.group(*celery_tasks).apply_async(queue="long")

--- a/public_data/management/commands/load_shapefile.py
+++ b/public_data/management/commands/load_shapefile.py
@@ -226,17 +226,17 @@ class Command(BaseCommand):
         land_ids = set([source.official_land_id for source in possible_sources])
 
         parser.add_argument("--dataset", type=str, required=True, choices=datasets)
-        parser.add_argument("--millesimes", type=int, nargs="*", default=[])
-        parser.add_argument("--land_id", type=str, required=True, choices=land_ids)
+        parser.add_argument("--land_id", type=str, choices=land_ids)
         parser.add_argument("--name", type=str, choices=names)
 
     def get_sources_queryset(self, options):
         sources = DataSource.objects.filter(
             dataset=options.get("dataset"),
-            official_land_id=options.get("land_id"),
             productor=DataSource.ProductorChoices.MDA,
-            millesimes__overlap=options.get("millesimes"),
         )
+        if options.get("land_id"):
+            sources = sources.filter(official_land_id=options.get("land_id"))
+
         if options.get("name"):
             sources = sources.filter(name=options.get("name"))
 

--- a/public_data/tasks.py
+++ b/public_data/tasks.py
@@ -1,20 +1,18 @@
 import logging
-from pydoc import locate
 
 from celery import shared_task
 
-from public_data.models.mixins import AutoLoadMixin
+from public_data.domain.artificialisation.use_case.CalculateCommuneArtificialAreas import (
+    CalculateCommuneArtificialAreas,
+)
+from public_data.models import Commune
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 @shared_task
-def load_data(class_name, verbose=False):
-    my_class: AutoLoadMixin = locate(class_name)
-
-    if not my_class:
-        raise ModuleNotFoundError(class_name)
-
-    logging.info("load data of %s (verbose=%s)", my_class, verbose)
-
-    my_class.load(verbose=verbose)
+def calculate_commune_artificial_area(commune_insee: str):
+    logger.info(f"Commune {commune_insee} - Calculating artificial areas")
+    commune = Commune.objects.get(insee=commune_insee)
+    artificial_areas = CalculateCommuneArtificialAreas.execute(commune)
+    logger.info(f"Commune {commune_insee} - Artificial areas calculated: {artificial_areas.count()}")

--- a/public_data/test/test_build_shapefile.py
+++ b/public_data/test/test_build_shapefile.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 from django.core.management import call_command
+from django.db import connection
 from django.test import TestCase
 
+from public_data.management.commands.build_shapefile import is_artif_case
 from public_data.models import DataSource
 
 
@@ -32,3 +34,28 @@ class TestBuildOcsge(TestCase):
 
         for file in expected_files:
             self.assertTrue(Path(file).exists())
+
+    def test_carriere_is_not_artif(self):
+        couverture = "CS1.1.2.1"  # zones à matériaux minéraux
+        usage = "US1.3"  # activité d'extraction
+
+        query = f"""
+        WITH test_data AS (
+            SELECT
+                '{couverture}' AS code_cs,
+                '{usage}' AS code_us
+        )
+        SELECT
+            {is_artif_case(
+                code_cs="code_cs",
+                code_us="code_us",
+            )}
+        FROM
+            test_data
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+
+        self.assertEqual(result[0], 0)


### PR DESCRIPTION


Avant MEP : 
- [x] Mettre les shapefiles recalculés dans le bucket de prod

Après MEP :
- [ ] Lancer la commande  `python manage.py fix_is_artif_carriere` sur tous les environnements