### PR TITLE
Hotfix: Utilisation d'un mauvais flag dans le context des exports

### DIFF
--- a/diagnostic_word/renderers.py
+++ b/diagnostic_word/renderers.py
@@ -258,8 +258,8 @@ class BaseRenderer:
                 ),
             }
 
-            # Artif comparison territories
-            if has_neighbors:
+            # Artif territories sub level
+            if not is_commune:
                 # Charts
                 artif_chart_comparison = charts.NetArtifComparaisonChartExport(diagnostic, level=diagnostic.level)
                 context |= {


### PR DESCRIPTION
<img width="730" alt="Capture d’écran 2024-07-05 à 12 03 48" src="https://github.com/MTES-MCT/sparte/assets/16525551/5b1e1375-5afb-4a56-bc3c-5445b91f22bf">

Le bug n'apparaît pas sur d'autres territoires car le flag utilisé pour ajouter dans le contexte tableau_evolution_artif était has_neighbors. Or, presque tous les diags ont des territoires de comparaison. En revanche, le département de l'Essonne n'en a pas.

**A creuser un potentiel bug ou oubli...**