### PR TITLE
Remplace GeoModelAdmin (déprécié sur django 5) par GISModelAdmin

### DIFF
--- a/metabase/admin.py
+++ b/metabase/admin.py
@@ -4,7 +4,7 @@ from metabase.models import StatDiagnostic
 
 
 @admin.register(StatDiagnostic)
-class StatDiagnosticAdmin(admin.GeoModelAdmin):
+class StatDiagnosticAdmin(admin.GISModelAdmin):
     model = StatDiagnostic
     list_display = (
         "created_date",

--- a/public_data/admin/CeremaAdmin.py
+++ b/public_data/admin/CeremaAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Cerema
 
 
 @admin.register(Cerema)
-class CeremaAdmin(admin.GeoModelAdmin):
+class CeremaAdmin(admin.GISModelAdmin):
     model = Cerema
     list_display = (
         "city_insee",

--- a/public_data/admin/CommuneAdmin.py
+++ b/public_data/admin/CommuneAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Commune
 
 
 @admin.register(Commune)
-class CommuneAdmin(admin.GeoModelAdmin):
+class CommuneAdmin(admin.GISModelAdmin):
     model = Commune
     list_display = (
         "insee",

--- a/public_data/admin/CommunePopAdmin.py
+++ b/public_data/admin/CommunePopAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import CommunePop
 
 
 @admin.register(CommunePop)
-class CommunePopAdmin(admin.GeoModelAdmin):
+class CommunePopAdmin(admin.GISModelAdmin):
     model = CommunePop

--- a/public_data/admin/DepartementAdmin.py
+++ b/public_data/admin/DepartementAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Departement
 
 
 @admin.register(Departement)
-class DepartementAdmin(admin.GeoModelAdmin):
+class DepartementAdmin(admin.GISModelAdmin):
     model = Departement
     list_display = (
         "id",

--- a/public_data/admin/EpciAdmin.py
+++ b/public_data/admin/EpciAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Epci
 
 
 @admin.register(Epci)
-class EpciAdmin(admin.GeoModelAdmin):
+class EpciAdmin(admin.GISModelAdmin):
     model = Epci
     list_display = (
         "id",

--- a/public_data/admin/OcsgeAdmin.py
+++ b/public_data/admin/OcsgeAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Ocsge
 
 
 @admin.register(Ocsge)
-class OcsgeAdmin(admin.GeoModelAdmin):
+class OcsgeAdmin(admin.GISModelAdmin):
     model = Ocsge
     list_display = (
         "id",

--- a/public_data/admin/OcsgeArtificialAreaAdmin.py
+++ b/public_data/admin/OcsgeArtificialAreaAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import ArtificialArea
 
 
 @admin.register(ArtificialArea)
-class OcsgeArtificialAreaAdmin(admin.GeoModelAdmin):
+class OcsgeArtificialAreaAdmin(admin.GISModelAdmin):
     model = ArtificialArea

--- a/public_data/admin/OcsgeCommuneDiffAdmin.py
+++ b/public_data/admin/OcsgeCommuneDiffAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import CommuneDiff
 
 
 @admin.register(CommuneDiff)
-class OcsgeCommuneDiffAdmin(admin.GeoModelAdmin):
+class OcsgeCommuneDiffAdmin(admin.GISModelAdmin):
     model = CommuneDiff

--- a/public_data/admin/OcsgeCommuneSolAdmin.py
+++ b/public_data/admin/OcsgeCommuneSolAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import CommuneSol
 
 
 @admin.register(CommuneSol)
-class OcsgeCommuneSolAdmin(admin.GeoModelAdmin):
+class OcsgeCommuneSolAdmin(admin.GISModelAdmin):
     model = CommuneSol

--- a/public_data/admin/OcsgeDiffAdmin.py
+++ b/public_data/admin/OcsgeDiffAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import OcsgeDiff
 
 
 @admin.register(OcsgeDiff)
-class OcsgeDiffAdmin(admin.GeoModelAdmin):
+class OcsgeDiffAdmin(admin.GISModelAdmin):
     model = OcsgeDiff

--- a/public_data/admin/OcsgeZoneConstruiteAdmin.py
+++ b/public_data/admin/OcsgeZoneConstruiteAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import ZoneConstruite
 
 
 @admin.register(ZoneConstruite)
-class OcsgeZoneConstruiteAdmin(admin.GeoModelAdmin):
+class OcsgeZoneConstruiteAdmin(admin.GISModelAdmin):
     model = ZoneConstruite

--- a/public_data/admin/RegionAdmin.py
+++ b/public_data/admin/RegionAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Region
 
 
 @admin.register(Region)
-class RegionAdmin(admin.GeoModelAdmin):
+class RegionAdmin(admin.GISModelAdmin):
     model = Region
     list_display = (
         "id",

--- a/public_data/admin/ScotAdmin.py
+++ b/public_data/admin/ScotAdmin.py
@@ -4,5 +4,5 @@ from public_data.models import Scot
 
 
 @admin.register(Scot)
-class ScotAdmin(admin.GeoModelAdmin):
+class ScotAdmin(admin.GISModelAdmin):
     model = Scot

--- a/public_data/admin/SudocuhAdmin.py
+++ b/public_data/admin/SudocuhAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import Sudocuh
 
 
 @admin.register(Sudocuh)
-class SudocuhAdmin(admin.GeoModelAdmin):
+class SudocuhAdmin(admin.GISModelAdmin):
     model = Sudocuh
     list_display = (
         "nom_commune",

--- a/public_data/admin/SudocuhEpciAdmin.py
+++ b/public_data/admin/SudocuhEpciAdmin.py
@@ -4,7 +4,7 @@ from public_data.models import SudocuhEpci
 
 
 @admin.register(SudocuhEpci)
-class SudocuhEpciAdmin(admin.GeoModelAdmin):
+class SudocuhEpciAdmin(admin.GISModelAdmin):
     model = SudocuhEpci
     list_display = (
         "nom_epci",


### PR DESCRIPTION
Erreur de CSP, mais a priori non bloquant car ça concerne une fonctionnalité de l'admin que nous n'utilisions pas.