### PR TITLE
Amélioration des performances du delete des tables incremental (dbt)

### DIFF
--- a/airflow/include/sql/sparte/macros/delete_from_this_where_field_not_in.sql
+++ b/airflow/include/sql/sparte/macros/delete_from_this_where_field_not_in.sql
@@ -6,5 +6,11 @@
     {% if not that_field %}
         {% set that_field = this_field %}
     {% endif %}
-    DELETE FROM {{ this }} WHERE {{ this_field }} not in (SELECT DISTINCT {{ that_field }} FROM {{ ref(table) }} )
+    DELETE FROM {{ this }}
+    WHERE {{ this_field }} in (
+        SELECT {{ this_field }} FROM {{ this }} AS foo
+        LEFT JOIN {{ ref(table) }} AS bar
+        ON foo.{{ this_field }} = bar.{{ that_field }}
+        WHERE {{ that_field }} is null
+    )
 {% endmacro %}


### PR DESCRIPTION
Nécessaire pour les models incrementaux de dbt qui ont un hard delete en post-hook : l'ancienne requête de delete pouvait prendre plusieurs heures.