### PR TITLE
Amélioration de la configuration tippecanoe

### DIFF
--- a/airflow/dags/create_ocsge_vector_tiles.py
+++ b/airflow/dags/create_ocsge_vector_tiles.py
@@ -61,9 +61,9 @@ def create_ocsge_vector_tiles():
             "--read-parallel",
             "--force",
             "--no-simplification-of-shared-nodes",
-            "--no-tile-size-limit",
-            "--base-zoom=10",
-            "--drop-densest-as-needed",
+            "--no-tiny-polygon-reduction",
+            "--base-zoom=11",
+            "--coalesce-densest-as-needed",
             "-zg",
         ]
 


### PR DESCRIPTION
Passage de "--no-tile-size-limit" à "--coalesce-densest-as-needed"
-> Réduit la taille des tuiles en nombre de features

Suppression de "--no-tiny-polygon-reduction",
Evite de former des petits carrés 
La doc : 
```
Don't combine the area of very small polygons into small squares that represent their combined area.
```

Passage de "--base-zoom=10" à "--base-zoom=11"
Niveau de zoom à partir duquel tous les détails sont affichés