### PR TITLE
Fix typo sur la table for_app_region: logement_vacants_available au lieu de logements_vacants_available

### DIFF
--- a/airflow/include/sql/sparte/models/for_app/for_app_region.sql
+++ b/airflow/include/sql/sparte/models/for_app/for_app_region.sql
@@ -11,6 +11,6 @@ SELECT
     ST_Transform(geom, 4326) AS mpoly,
     srid_source AS srid_source,
     TRUE as autorisation_logement_available,
-    TRUE as logement_vacants_available
+    TRUE as logements_vacants_available
 FROM
     {{ ref('region') }}


### PR DESCRIPTION
s manquant