### PR TITLE
Amélioration du responsive

### DIFF
--- a/assets/scripts/components/layout/Dashboard.tsx
+++ b/assets/scripts/components/layout/Dashboard.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import { useGetProjectQuery } from '@services/api';
 import { setProjectData } from '@store/projectSlice';
-import { selectIsNavbarOpen, closeNavbar, openNavbar, selectIsNavbarClosedByUser } from '@store/navbarSlice';
+import { selectIsNavbarOpen, handleResponsiveNavbar } from '@store/navbarSlice';
 import useWindowSize from '@hooks/useWindowSize';
 import useMatomoTracking from '@hooks/useMatomoTracking';
 import useUrls from '@hooks/useUrls';
@@ -29,8 +29,8 @@ interface DashboardProps {
     projectId: string;
 }
 
-const Main = styled.main<{ $isOpen: boolean }>`
-    margin-left: ${({ $isOpen }) => ($isOpen ? '280px' : '0')};
+const Main = styled.main<{ $isOpen: boolean; $isMobile: boolean }>`
+    margin-left: ${({ $isOpen, $isMobile }) => ($isMobile ? '0' : $isOpen ? '280px' : '0')};
     margin-top: 80px;
     flex-grow: 1;
     display: flex;
@@ -52,7 +52,6 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
     const urls = useUrls();
 
     const isOpen = useSelector((state: RootState) => selectIsNavbarOpen(state));
-    const isClosedByUser = useSelector(selectIsNavbarClosedByUser);
     const { isMobile } = useWindowSize();
 
     useEffect(() => {
@@ -62,13 +61,8 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
     }, [data, dispatch]);
 
     useEffect(() => {
-        if (isMobile) {
-            dispatch(closeNavbar());
-            
-        } else if (!isClosedByUser && !isOpen) {            
-            dispatch(openNavbar());
-        }
-    }, [isMobile, isClosedByUser, isOpen, dispatch]);
+        dispatch(handleResponsiveNavbar({ isMobile }));
+    }, [isMobile, dispatch]);
 
     return (
         <>
@@ -78,7 +72,7 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
                     <Router>
                         <TrackingWrapper />
                         <Navbar projectData={data} />
-                        <Main $isOpen={isOpen}>
+                        <Main $isOpen={isOpen} $isMobile={isMobile}>
                             <TopBar />
                             <Content>
                                 <Routes>

--- a/assets/scripts/components/layout/Dashboard.tsx
+++ b/assets/scripts/components/layout/Dashboard.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import { useGetProjectQuery } from '@services/api';
 import { setProjectData } from '@store/projectSlice';
-import { selectIsNavbarOpen, handleResponsiveNavbar } from '@store/navbarSlice';
+import { selectIsNavbarOpen } from '@store/navbarSlice';
 import useWindowSize from '@hooks/useWindowSize';
 import useMatomoTracking from '@hooks/useMatomoTracking';
 import useUrls from '@hooks/useUrls';
@@ -59,10 +59,6 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
         dispatch(setProjectData(data));        
     }
     }, [data, dispatch]);
-
-    useEffect(() => {
-        dispatch(handleResponsiveNavbar({ isMobile }));
-    }, [isMobile, dispatch]);
 
     return (
         <>

--- a/assets/scripts/components/layout/Footer.tsx
+++ b/assets/scripts/components/layout/Footer.tsx
@@ -20,6 +20,10 @@ const NavLinks = styled.nav`
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    @media (max-width: 1080px) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 `;
 
 const NavLink = styled.a`

--- a/assets/scripts/components/layout/Header.tsx
+++ b/assets/scripts/components/layout/Header.tsx
@@ -28,7 +28,7 @@ const HeaderContainer = styled.header`
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 999;
+    z-index: 1000;
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/assets/scripts/components/layout/Header.tsx
+++ b/assets/scripts/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import useWindowSize from '@hooks/useWindowSize';
 import SearchBar from '@components/widgets/SearchBar';
 
 interface HeaderData {
@@ -23,6 +24,9 @@ interface MenuItem {
     target?: string;
 }
 
+const activeColor = '#4318FF';
+const secondaryColor = '#a1a1f8';
+
 const HeaderContainer = styled.header`
     position: fixed;
     top: 0;
@@ -35,11 +39,6 @@ const HeaderContainer = styled.header`
     padding: 0.3rem 1rem;
     background-color: #fff;
     border-bottom: 1px solid #EEF2F7;
-
-    @media (max-width: 768px) {
-        flex-direction: column;
-        align-items: flex-start;
-    }
 `;
 
 const LogoContainer = styled.div`
@@ -58,28 +57,43 @@ const LogoLink = styled.a`
     text-decoration: none;
 `;
 
-const ButtonContainer = styled.div`
-    display: flex;
+const ButtonContainer = styled.div<{ $isMobile: boolean, $isMenuOpen: boolean }>`
+    display: ${({ $isMobile, $isMenuOpen }) => ($isMobile ? ($isMenuOpen ? 'flex' : 'none') : 'flex')};
     flex-grow: 1;
     justify-content: end;
+    ${({ $isMobile, $isMenuOpen }) => $isMobile && $isMenuOpen && `
+        position: absolute;
+        top: 100%;
+        left: 0;
+        width: 100%;
+        background-color: #fff;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+    `}
 `;
 
-const SearchBarContainer = styled.div`
+const SearchBarContainer = styled.div<{ $isMobile: boolean }>`
     flex-grow: 1;
     margin: 0 2rem;
     display: flex;
     justify-content: end;
     max-width: 550px;
+    ${({ $isMobile }) => $isMobile && `
+        width: 100%;
+    `}
 `;
 
-const NavLinks = styled.nav`
+const NavLinks = styled.nav<{ $isMobile: boolean }>`
     display: flex;
     align-items: center;
     gap: 1rem;
-
-    @media (max-width: 768px) {
-        margin-top: 1rem;
-    }
+    ${({ $isMobile }) => $isMobile && `
+        flex-direction: column;
+        width: 100%;
+    `}
 `;
 
 const NavLink = styled.a`
@@ -99,15 +113,31 @@ const NavLink = styled.a`
         color: #000091;
         background: #f6f6f6 !important;
     }
+`;
 
-    @media (max-width: 768px) {
-        margin-left: 0;
-        margin-right: 1rem;
+const ButtonToggleMenu = styled.i<{ $isMobile: boolean }>`
+    font-size: 17px;
+    padding: 7px 10px;
+    border-radius: 9px;
+    color: ${secondaryColor};
+    cursor: pointer;
+    margin-right: 1rem;
+    transition: transform 0.3s ease;
+    border: 1px solid #d5d9de;
+    font-weight: 900;
+    -webkit-text-stroke: 0.04rem;
+    transition: color 0.3s ease;
+    display: ${({ $isMobile }) => ($isMobile ? 'block' : 'none')};
+
+    &:hover {
+        color: ${activeColor};
     }
 `;
 
 const Header = () => {
     const [data, setData] = useState<HeaderData | null>(null);
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const { isMobile } = useWindowSize(980);
 
     // La composition du header et notamment les urls des liens sont récupérés via le contexte Django => project/templates/layout/base.html => #header-data
     useEffect(() => {
@@ -117,6 +147,12 @@ const Header = () => {
             setData(parsedData);
         }
     }, []);
+
+    // responsive
+    useEffect(() => {
+        if (isMobile)
+            setIsMenuOpen(false); // Ferme le menu automatiquement si on passe en mode mobile
+    }, [isMobile]);
 
     return (
         <HeaderContainer>
@@ -140,11 +176,12 @@ const Header = () => {
                     )
                 ))}
             </LogoContainer>
-            <ButtonContainer>
-                <SearchBarContainer>
+            <ButtonToggleMenu className="bi bi-list" $isMobile={isMobile} onClick={() => setIsMenuOpen(!isMenuOpen)} />
+            <ButtonContainer $isMobile={isMobile} $isMenuOpen={isMenuOpen}>
+                <SearchBarContainer $isMobile={isMobile}>
                     <SearchBar createUrl={data?.search.createUrl} />
                 </SearchBarContainer>
-                <NavLinks>
+                <NavLinks $isMobile={isMobile}>
                     {data?.menuItems.map((item) => (
                         <NavLink
                             key={item.label}

--- a/assets/scripts/components/layout/Header.tsx
+++ b/assets/scripts/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import useWindowSize from '@hooks/useWindowSize';
+import { Tooltip } from 'react-tooltip'
 import SearchBar from '@components/widgets/SearchBar';
 
 interface HeaderData {
@@ -176,7 +177,14 @@ const Header = () => {
                     )
                 ))}
             </LogoContainer>
-            <ButtonToggleMenu className="bi bi-list" $isMobile={isMobile} onClick={() => setIsMenuOpen(!isMenuOpen)} />
+            <ButtonToggleMenu
+                className="bi bi-list"
+                $isMobile={isMobile}
+                onClick={() => setIsMenuOpen(!isMenuOpen)}
+                data-tooltip-id="tooltip-close-sidebar"
+                data-tooltip-content={isMenuOpen ? "Fermer le menu" : "Ouvrir le menu"}
+            />
+            <Tooltip id="tooltip-close-sidebar" className="fr-text--xs" />
             <ButtonContainer $isMobile={isMobile} $isMenuOpen={isMenuOpen}>
                 <SearchBarContainer $isMobile={isMobile}>
                     <SearchBar createUrl={data?.search.createUrl} />

--- a/assets/scripts/components/layout/Navbar.tsx
+++ b/assets/scripts/components/layout/Navbar.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '@store/store';
 import { useLocation, Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
+import { selectIsNavbarOpen } from '@store/navbarSlice';
 import useHtmx from '@hooks/useHtmx';
 import useUrls from '@hooks/useUrls';
 import Button from '@components/ui/Button';
@@ -53,16 +56,17 @@ const LinkStyle = css<{ $isActive: boolean }>`
     }
 `;
 
-const Container = styled.aside`
+const Container = styled.aside<{ $isOpen: boolean }>`
     position: fixed;
-    left: 0;
+    left: ${({ $isOpen }) => ($isOpen ? '0' : '-280px')};
     top: 80px;
     bottom: 0;
     width: 280px;
     display: flex;
     flex-direction: column;
-    background: ##04023c;
+    background: #fff;
     border-right: 1px solid #EEF2F7;
+    transition: left 0.3s ease;
 `;
 
 const MenuList = styled.ul`
@@ -126,7 +130,7 @@ const DownloadContainer = styled.div`
     padding: 1rem;
     border-radius: 6px;
     background: #cacafb;
-    
+
     &:hover ${DownloadList} {
         height: 192px;
     }
@@ -169,6 +173,7 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
     const [data, setData] = useState<NavbarData | null>(null);
     const urls = useUrls();
     const htmxRef = useHtmx([urls]);
+    const isOpen = useSelector((state: RootState) => selectIsNavbarOpen(state));
 
     const shouldDisplayDownloads = [
         ConsoCorrectionStatusEnum.UNCHANGED,
@@ -214,7 +219,7 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
     );
 
     return (
-        <Container aria-label="Sidebar" ref={htmxRef}>
+        <Container aria-label="Sidebar" ref={htmxRef} $isOpen={isOpen}>
             <MenuList role="tree" aria-label="Sidebar menu">
                 {data?.menuItems.map((menu) => (
                     <Menu key={menu.label}>

--- a/assets/scripts/components/layout/Navbar.tsx
+++ b/assets/scripts/components/layout/Navbar.tsx
@@ -75,8 +75,6 @@ const MenuList = styled.ul`
     list-style: none;
     padding: 1rem 0 0;
     margin: 0;
-    flex: 1 1 0%;
-    overflow-y: auto;
 `;
 
 const Menu = styled.li`
@@ -118,24 +116,28 @@ const Icon = styled.i`
     margin-right: 0.7em;
 `;
 
-const DownloadList = styled.ul`
-    height: 0;
-    overflow: hidden;
-    transition: height 0.3s ease;
+const DownloadList = styled.ul<{ $isMobile: boolean }>`
     margin: 0;
     padding: 0;
     list-style-type: none;
+    ${({ $isMobile }) => !$isMobile && `
+        height: 0;
+        overflow: hidden;
+        transition: height 0.3s ease;
+    `}
 `;
 
-const DownloadContainer = styled.div`
+const DownloadContainer = styled.div<{ $isMobile: boolean }>`
     margin: 1rem;
     padding: 1rem;
     border-radius: 6px;
     background: #cacafb;
 
-    &:hover ${DownloadList} {
-        height: 192px;
-    }
+    ${({ $isMobile }) => !$isMobile && `
+        &:hover ${DownloadList} {
+            height: 192px;
+        }
+    `}
 `;
 
 const DownloadTitle = styled.div`
@@ -170,10 +172,15 @@ const DownloadListItem = styled.li`
     }
 `;
 
+const NavContainer = styled.div`
+    flex: 1 1 0%;
+    overflow-y: auto;
+`;
+
 const NavbarHeader = styled.div`
     display: flex;
     padding: 1.5rem 1rem;
-    padding-bottom: 0;
+    padding-bottom: 0.5rem;
 `;
 
 const Overlay = styled.div<{ $isOpen: boolean }>`
@@ -256,6 +263,99 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
         </SubMenuList>
     );
 
+    const renderDownloadItems = () => (
+        <DownloadContainer $isMobile={isMobile}>
+            <DownloadTitle>
+                <i className="bi bi-box-arrow-down"></i>
+                <div>Téléchargements</div>
+            </DownloadTitle>
+            <DownloadList $isMobile={isMobile}>
+                <DownloadListItem>
+                    <Button
+                        type="htmx"
+                        icon="bi bi-file-earmark-word"
+                        label="Analyse de Consommation"
+                        htmxAttrs={{
+                            'data-hx-get': urls.dowloadConsoReport,
+                            'data-hx-target': '#diag_word_form',
+                            'data-fr-opened': 'false',
+                            'aria-controls': 'fr-modal-download-word',
+                        }}
+                        onClick={() => {
+                            resetModalContent();
+                            if (window.trackEvent)
+                                window.trackEvent(
+                                    'diagnostic_download_funnel',
+                                    'click_button_conso_report_download',
+                                    'conso_report_download_button_clicked'
+                                );
+                        }}
+                    />
+                </DownloadListItem>
+                <DownloadListItem>
+                    <Button
+                        type="htmx"
+                        icon="bi bi-file-earmark-word"
+                        label="Analyse complète"
+                        htmxAttrs={{
+                            'data-hx-get': urls.dowloadFullReport,
+                            'data-hx-target': '#diag_word_form',
+                            'data-fr-opened': 'false',
+                            'aria-controls': 'fr-modal-download-word',
+                        }}
+                        onClick={() => {
+                            resetModalContent();
+                            if (window.trackEvent)
+                                window.trackEvent(
+                                    'diagnostic_download_funnel',
+                                    'click_button_diagnostic_download_word',
+                                    'diagnostic_download_word_button_clicked'
+                                );
+                        }}
+                    />
+                </DownloadListItem>
+                <DownloadListItem>
+                    <Button
+                        type="htmx"
+                        icon="bi bi-file-earmark-word"
+                        label="Rapport triennal local"
+                        htmxAttrs={{
+                            'data-hx-get': urls.dowloadLocalReport,
+                            'data-hx-target': '#diag_word_form',
+                            'data-fr-opened': 'false',
+                            'aria-controls': 'fr-modal-download-word',
+                        }}
+                        onClick={() => {
+                            resetModalContent();
+                            if (window.trackEvent)
+                                window.trackEvent(
+                                    'diagnostic_download_funnel',
+                                    'click_button_local_report_download',
+                                    'local_report_download_button_clicked'
+                                );
+                        }}
+                    />
+                </DownloadListItem>
+                <DownloadListItem>
+                    <Button
+                        type="link"
+                        icon="bi bi-file-earmark-excel"
+                        label="Export Excel"
+                        url={urls.dowloadCsvReport}
+                        onClick={() => {
+                            if (window.trackEvent)
+                                window.trackEvent(
+                                    'diagnostic_download_funnel',
+                                    'click_button_diagnostic_download_excel',
+                                    'diagnostic_download_excel_success'
+                                );
+                        }}
+                    />
+                </DownloadListItem>
+            </DownloadList>
+        </DownloadContainer>
+    );
+    
     return (
         <>
             {isMobile && <Overlay $isOpen={isOpen} onClick={() => dispatch(toggleNavbar())} />}
@@ -263,115 +363,31 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
                 <NavbarHeader>
                     <ButtonToggleNavbar />
                 </NavbarHeader>
-                <MenuList role="tree" aria-label="Sidebar menu">
-                    {data?.menuItems.map((menu) => (
-                        <Menu key={menu.label}>
-                            {menu.url ? (
-                                <MenuTitleLink to={menu.url} $isActive={isActive(menu.url)}>
-                                    {menu.icon && <Icon className={`bi ${menu.icon}`} />}
-                                    {menu.label}
-                                </MenuTitleLink>
-                            ) : (
-                                <MenuTitle>
-                                    {menu.icon && <Icon className={`bi ${menu.icon}`} />}
-                                    {menu.label}
-                                </MenuTitle>
-                            )}
-                            {menu.subMenu && renderMenuItems(menu.subMenu)}
-                        </Menu>
-                    ))}
-                </MenuList>
-                {urls && shouldDisplayDownloads && (
-                    <DownloadContainer>
-                        <DownloadTitle>
-                            <i className="bi bi-box-arrow-down"></i>
-                            <div>Téléchargements</div>
-                        </DownloadTitle>
-                        <DownloadList>
-                            <DownloadListItem>
-                                <Button
-                                    type="htmx"
-                                    icon="bi bi-file-earmark-word"
-                                    label="Analyse de Consommation"
-                                    htmxAttrs={{
-                                        'data-hx-get': urls.dowloadConsoReport,
-                                        'data-hx-target': '#diag_word_form',
-                                        'data-fr-opened': 'false',
-                                        'aria-controls': 'fr-modal-download-word',
-                                    }}
-                                    onClick={() => {
-                                        resetModalContent();
-                                        if (window.trackEvent)
-                                            window.trackEvent(
-                                                'diagnostic_download_funnel',
-                                                'click_button_conso_report_download',
-                                                'conso_report_download_button_clicked'
-                                            );
-                                    }}
-                                />
-                            </DownloadListItem>
-                            <DownloadListItem>
-                                <Button
-                                    type="htmx"
-                                    icon="bi bi-file-earmark-word"
-                                    label="Analyse complète"
-                                    htmxAttrs={{
-                                        'data-hx-get': urls.dowloadFullReport,
-                                        'data-hx-target': '#diag_word_form',
-                                        'data-fr-opened': 'false',
-                                        'aria-controls': 'fr-modal-download-word',
-                                    }}
-                                    onClick={() => {
-                                        resetModalContent();
-                                        if (window.trackEvent)
-                                            window.trackEvent(
-                                                'diagnostic_download_funnel',
-                                                'click_button_diagnostic_download_word',
-                                                'diagnostic_download_word_button_clicked'
-                                            );
-                                    }}
-                                />
-                            </DownloadListItem>
-                            <DownloadListItem>
-                                <Button
-                                    type="htmx"
-                                    icon="bi bi-file-earmark-word"
-                                    label="Rapport triennal local"
-                                    htmxAttrs={{
-                                        'data-hx-get': urls.dowloadLocalReport,
-                                        'data-hx-target': '#diag_word_form',
-                                        'data-fr-opened': 'false',
-                                        'aria-controls': 'fr-modal-download-word',
-                                    }}
-                                    onClick={() => {
-                                        resetModalContent();
-                                        if (window.trackEvent)
-                                            window.trackEvent(
-                                                'diagnostic_download_funnel',
-                                                'click_button_local_report_download',
-                                                'local_report_download_button_clicked'
-                                            );
-                                    }}
-                                />
-                            </DownloadListItem>
-                            <DownloadListItem>
-                                <Button
-                                    type="link"
-                                    icon="bi bi-file-earmark-excel"
-                                    label="Export Excel"
-                                    url={urls.dowloadCsvReport}
-                                    onClick={() => {
-                                        if (window.trackEvent)
-                                            window.trackEvent(
-                                                'diagnostic_download_funnel',
-                                                'click_button_diagnostic_download_excel',
-                                                'diagnostic_download_excel_success'
-                                            );
-                                    }}
-                                />
-                            </DownloadListItem>
-                        </DownloadList>
-                    </DownloadContainer>
+                <NavContainer>
+                    <MenuList role="tree" aria-label="Sidebar menu">
+                        {data?.menuItems.map((menu) => (
+                            <Menu key={menu.label}>
+                                {menu.url ? (
+                                    <MenuTitleLink to={menu.url} $isActive={isActive(menu.url)}>
+                                        {menu.icon && <Icon className={`bi ${menu.icon}`} />}
+                                        {menu.label}
+                                    </MenuTitleLink>
+                                ) : (
+                                    <MenuTitle>
+                                        {menu.icon && <Icon className={`bi ${menu.icon}`} />}
+                                        {menu.label}
+                                    </MenuTitle>
+                                )}
+                                {menu.subMenu && renderMenuItems(menu.subMenu)}
+                            </Menu>
+                        ))}
+                    </MenuList>
+                    {urls && shouldDisplayDownloads && isMobile && (
+                        renderDownloadItems()
+                    )}
+                </NavContainer>
+                {urls && shouldDisplayDownloads && !isMobile && (
+                    renderDownloadItems()
                 )}
             </Container>
         </>

--- a/assets/scripts/components/layout/Navbar.tsx
+++ b/assets/scripts/components/layout/Navbar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import { toggleNavbar, selectIsNavbarOpen } from '@store/navbarSlice';
+import { toggleNavbar, selectIsNavbarOpen, handleResponsiveNavbar } from '@store/navbarSlice';
 import useHtmx from '@hooks/useHtmx';
 import useWindowSize from '@hooks/useWindowSize';
 import useUrls from '@hooks/useUrls';
@@ -223,6 +223,19 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
             modalContent.innerHTML = '<div class="fr-custom-loader"></div>';
         }
     };
+
+    // responsive
+    useEffect(() => {
+        dispatch(handleResponsiveNavbar({ isMobile }));
+    }, [isMobile, dispatch]);
+
+    useEffect(() => {
+        if (isOpen && isMobile) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = 'auto';
+        }
+    }, [isOpen, isMobile]);
 
     const renderMenuItems = (items: SubMenu[]) => (
         <SubMenuList>

--- a/assets/scripts/components/layout/Navbar.tsx
+++ b/assets/scripts/components/layout/Navbar.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '@store/store';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import { selectIsNavbarOpen } from '@store/navbarSlice';
+import { toggleNavbar, selectIsNavbarOpen } from '@store/navbarSlice';
 import useHtmx from '@hooks/useHtmx';
 import useUrls from '@hooks/useUrls';
 import Button from '@components/ui/Button';
+import ButtonToggleNavbar from "@components/ui/ButtonToggleNavbar";
 import { ConsoCorrectionStatusEnum } from '@components/widgets/ConsoCorrectionStatus';
 
 interface NavbarData {
@@ -168,12 +168,20 @@ const DownloadListItem = styled.li`
     }
 `;
 
+const NavbarHeader = styled.div`
+    display: flex;
+    padding: 1.5rem 1rem;
+    padding-bottom: 0;
+`;
+
 const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
     const location = useLocation();
     const [data, setData] = useState<NavbarData | null>(null);
     const urls = useUrls();
     const htmxRef = useHtmx([urls]);
-    const isOpen = useSelector((state: RootState) => selectIsNavbarOpen(state));
+
+    const dispatch = useDispatch();
+    const isOpen = useSelector(selectIsNavbarOpen);
 
     const shouldDisplayDownloads = [
         ConsoCorrectionStatusEnum.UNCHANGED,
@@ -220,6 +228,9 @@ const Navbar: React.FC<{ projectData: any }> = ({ projectData }) => {
 
     return (
         <Container aria-label="Sidebar" ref={htmxRef} $isOpen={isOpen}>
+            <NavbarHeader>
+                <ButtonToggleNavbar />
+            </NavbarHeader>
             <MenuList role="tree" aria-label="Sidebar menu">
                 {data?.menuItems.map((menu) => (
                     <Menu key={menu.label}>

--- a/assets/scripts/components/layout/TopBar.tsx
+++ b/assets/scripts/components/layout/TopBar.tsx
@@ -1,13 +1,14 @@
 import React, { memo, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { RootState } from '@store/store';
 import { formatDateTime } from '@utils/formatUtils';
 import { useLocation } from 'react-router-dom';
-import { toggleNavbar, selectIsNavbarOpen } from '@store/navbarSlice';
 import styled from 'styled-components';
 import useHtmx from '@hooks/useHtmx';
 import useUrls from '@hooks/useUrls';
+import { selectIsNavbarOpen } from "@store/navbarSlice";
 import Divider from '@components/ui/Divider';
+import ButtonToggleNavbar from "@components/ui/ButtonToggleNavbar";
 
 const primaryColor = '#313178';
 const activeColor = '#4318FF';
@@ -73,18 +74,6 @@ const ItemContent = styled.div`
     }
 `;
 
-const IconToggle = styled.i<{ $isOpen: boolean }>`
-    background: #a2a2f8;
-    font-size: 22px;
-    padding: 7px;
-    border-radius: 50%;
-    color: #fff;
-    cursor: pointer;
-    margin-right: 1rem;
-    transition: transform 0.3s ease;
-    transform: ${({ $isOpen }) => ($isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
-`;
-
 const TopBar: React.FC = () => {
     const projectData = useSelector((state: RootState) => state.project.projectData);
     const memoizedProjectData = useMemo(() => projectData, [projectData?.id]);
@@ -94,18 +83,12 @@ const TopBar: React.FC = () => {
     const location = useLocation();
     const pathsToHidePeriod = ['vacance-des-logements'];
     const shouldDisplayPeriod = !pathsToHidePeriod.some(path => location.pathname.endsWith(path));
-
-    const dispatch = useDispatch();
     const isOpen = useSelector(selectIsNavbarOpen);
 
     return (
         <Container ref={htmxRef}>
             <div className="d-flex align-items-center">
-                <IconToggle 
-                    className="bi bi-layout-sidebar" 
-                    onClick={() => dispatch(toggleNavbar())} 
-                    $isOpen={isOpen} 
-                />
+                { !isOpen && <ButtonToggleNavbar /> }
                 <div>
                     <Title>{ memoizedProjectData?.territory_name }</Title>
                     <SubTitle>Diagnostic créé le { formattedDate }</SubTitle>

--- a/assets/scripts/components/layout/TopBar.tsx
+++ b/assets/scripts/components/layout/TopBar.tsx
@@ -5,6 +5,7 @@ import { formatDateTime } from '@utils/formatUtils';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import useHtmx from '@hooks/useHtmx';
+import useWindowSize from '@hooks/useWindowSize';
 import useUrls from '@hooks/useUrls';
 import { selectIsNavbarOpen } from "@store/navbarSlice";
 import Divider from '@components/ui/Divider';
@@ -83,8 +84,9 @@ const TopBar: React.FC = () => {
     const location = useLocation();
     const pathsToHidePeriod = ['vacance-des-logements'];
     const shouldDisplayPeriod = !pathsToHidePeriod.some(path => location.pathname.endsWith(path));
+    const { isMobile } = useWindowSize(980);
     const isOpen = useSelector(selectIsNavbarOpen);
-
+    
     return (
         <Container ref={htmxRef}>
             <div className="d-flex align-items-center">
@@ -94,33 +96,35 @@ const TopBar: React.FC = () => {
                     <SubTitle>Diagnostic créé le { formattedDate }</SubTitle>
                 </div>
             </div>
-            <ItemContainer>
-                { shouldDisplayPeriod && (
-                    <>
-                        <Item>
-                            <ItemTitle><i className="bi bi-calendar4-range"></i> Période d'analyse</ItemTitle>
-                            <ItemContent>
-                                De { memoizedProjectData?.analyse_start_date } à { memoizedProjectData?.analyse_end_date }
-                                {urls &&
-                                    <button 
-                                        data-fr-opened="false" 
-                                        aria-controls="fr-modal-1" 
-                                        title="Modifier la période d'analyse du diagnostic" 
-                                        data-hx-get={urls.setPeriod} 
-                                        data-hx-target="#update_period_form">
-                                        <span className="fr-icon-pencil-fill fr-icon--sm" aria-hidden="true"></span>
-                                    </button>
-                                }
-                            </ItemContent>
-                        </Item>
-                        <Divider color="#e3e4e9" size="30px" />
-                    </>
-                )}
-                <Item>
-                    <ItemTitle><i className="bi bi-bullseye"></i> Maille d'analyse</ItemTitle>
-                    <ItemContent>{ memoizedProjectData?.level_label }</ItemContent>
-                </Item>
-            </ItemContainer>
+            { !isMobile && (
+                <ItemContainer>
+                    { shouldDisplayPeriod && (
+                        <>
+                            <Item>
+                                <ItemTitle><i className="bi bi-calendar4-range"></i> Période d'analyse</ItemTitle>
+                                <ItemContent>
+                                    De { memoizedProjectData?.analyse_start_date } à { memoizedProjectData?.analyse_end_date }
+                                    {urls &&
+                                        <button 
+                                            data-fr-opened="false" 
+                                            aria-controls="fr-modal-1" 
+                                            title="Modifier la période d'analyse du diagnostic" 
+                                            data-hx-get={urls.setPeriod} 
+                                            data-hx-target="#update_period_form">
+                                            <span className="fr-icon-pencil-fill fr-icon--sm" aria-hidden="true"></span>
+                                        </button>
+                                    }
+                                </ItemContent>
+                            </Item>
+                            <Divider color="#e3e4e9" size="30px" />
+                        </>
+                    )}
+                    <Item>
+                        <ItemTitle><i className="bi bi-bullseye"></i> Maille d'analyse</ItemTitle>
+                        <ItemContent>{ memoizedProjectData?.level_label }</ItemContent>
+                    </Item>
+                </ItemContainer>
+            )}
         </Container>
     );
 };

--- a/assets/scripts/components/layout/TopBar.tsx
+++ b/assets/scripts/components/layout/TopBar.tsx
@@ -1,8 +1,9 @@
 import React, { memo, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@store/store';
 import { formatDateTime } from '@utils/formatUtils';
 import { useLocation } from 'react-router-dom';
+import { toggleNavbar, selectIsNavbarOpen } from '@store/navbarSlice';
 import styled from 'styled-components';
 import useHtmx from '@hooks/useHtmx';
 import useUrls from '@hooks/useUrls';
@@ -72,6 +73,18 @@ const ItemContent = styled.div`
     }
 `;
 
+const IconToggle = styled.i<{ $isOpen: boolean }>`
+    background: #a2a2f8;
+    font-size: 22px;
+    padding: 7px;
+    border-radius: 50%;
+    color: #fff;
+    cursor: pointer;
+    margin-right: 1rem;
+    transition: transform 0.3s ease;
+    transform: ${({ $isOpen }) => ($isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
+`;
+
 const TopBar: React.FC = () => {
     const projectData = useSelector((state: RootState) => state.project.projectData);
     const memoizedProjectData = useMemo(() => projectData, [projectData?.id]);
@@ -82,11 +95,21 @@ const TopBar: React.FC = () => {
     const pathsToHidePeriod = ['vacance-des-logements'];
     const shouldDisplayPeriod = !pathsToHidePeriod.some(path => location.pathname.endsWith(path));
 
+    const dispatch = useDispatch();
+    const isOpen = useSelector(selectIsNavbarOpen);
+
     return (
         <Container ref={htmxRef}>
-            <div>
-                <Title>{ memoizedProjectData?.territory_name }</Title>
-                <SubTitle>Diagnostic créé le { formattedDate }</SubTitle>
+            <div className="d-flex align-items-center">
+                <IconToggle 
+                    className="bi bi-layout-sidebar" 
+                    onClick={() => dispatch(toggleNavbar())} 
+                    $isOpen={isOpen} 
+                />
+                <div>
+                    <Title>{ memoizedProjectData?.territory_name }</Title>
+                    <SubTitle>Diagnostic créé le { formattedDate }</SubTitle>
+                </div>
             </div>
             <ItemContainer>
                 { shouldDisplayPeriod && (

--- a/assets/scripts/components/ui/ButtonToggleNavbar.tsx
+++ b/assets/scripts/components/ui/ButtonToggleNavbar.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { toggleNavbar, selectIsNavbarOpen } from "@store/navbarSlice";
+import { Tooltip } from 'react-tooltip'
+import styled from "styled-components";
+
+const activeColor = '#4318FF';
+const secondaryColor = '#a1a1f8';
+
+const IconToggle = styled.i<{ $isOpen: boolean }>`
+    font-size: 17px;
+    padding: 7px 10px;
+    border-radius: 9px;
+    color: ${secondaryColor};
+    cursor: pointer;
+    margin-right: 1rem;
+    transition: transform 0.3s ease;
+    border: 1px solid #d5d9de;
+    font-weight: 900;
+    -webkit-text-stroke: 0.04rem;
+    transition: color 0.3s ease;
+
+    &:hover {
+        color: ${activeColor};
+    }
+`;
+
+const ButtonToggleNavbar: React.FC = () => {
+    const dispatch = useDispatch();
+    const isOpen = useSelector(selectIsNavbarOpen);
+
+    return (
+            <>
+                <IconToggle 
+                    className="bi bi-layout-sidebar" 
+                    onClick={() => dispatch(toggleNavbar())} 
+                    $isOpen={isOpen}
+                    data-tooltip-id="tooltip-close-sidebar"
+                    data-tooltip-content={isOpen ? "Fermer la barre latérale" : "Ouvrir la barre latérale"}
+                />
+                <Tooltip id="tooltip-close-sidebar" className="fr-text--xs" />
+            </>
+    );
+};
+
+export default ButtonToggleNavbar;

--- a/assets/scripts/components/ui/ButtonToggleNavbar.tsx
+++ b/assets/scripts/components/ui/ButtonToggleNavbar.tsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 const activeColor = '#4318FF';
 const secondaryColor = '#a1a1f8';
 
-const IconToggle = styled.i<{ $isOpen: boolean }>`
+const IconToggle = styled.i`
     font-size: 17px;
     padding: 7px 10px;
     border-radius: 9px;
@@ -33,8 +33,7 @@ const ButtonToggleNavbar: React.FC = () => {
             <>
                 <IconToggle 
                     className="bi bi-layout-sidebar" 
-                    onClick={() => dispatch(toggleNavbar())} 
-                    $isOpen={isOpen}
+                    onClick={() => dispatch(toggleNavbar())}
                     data-tooltip-id="tooltip-close-sidebar"
                     data-tooltip-content={isOpen ? "Fermer la barre latérale" : "Ouvrir la barre latérale"}
                 />

--- a/assets/scripts/hooks/useWindowSize.ts
+++ b/assets/scripts/hooks/useWindowSize.ts
@@ -1,0 +1,41 @@
+import { useState, useLayoutEffect, useCallback } from 'react';
+
+interface WindowSize {
+    width: number;
+    isMobile: boolean;
+}
+
+const useWindowSize = (breakpoint: number = 768): WindowSize => {
+    const [windowSize, setWindowSize] = useState<WindowSize>({
+        width: window.innerWidth,
+        isMobile: window.innerWidth < breakpoint
+    });
+
+    const handleResize = useCallback(() => {
+        setWindowSize({
+            width: window.innerWidth,
+            isMobile: window.innerWidth < breakpoint
+        });
+    }, [breakpoint]);
+
+    useLayoutEffect(() => {
+        // Debounce pour optimiser les performances
+        let timeoutId: NodeJS.Timeout;
+        const debouncedHandleResize = () => {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(handleResize, 150);
+        };
+
+        window.addEventListener('resize', debouncedHandleResize);
+
+        // Nettoyage initial pour éviter les fuites de mémoire
+        return () => {
+            clearTimeout(timeoutId);
+            window.removeEventListener('resize', debouncedHandleResize);
+        };
+    }, [handleResize]);
+
+    return windowSize;
+};
+
+export default useWindowSize;

--- a/assets/scripts/store/navbarSlice.ts
+++ b/assets/scripts/store/navbarSlice.ts
@@ -3,12 +3,12 @@ import { RootState } from '@store/store';
 
 interface NavbarState {
     isOpen: boolean;
-    isClosedByUser: boolean;
+    wasOpened: boolean; // Mémorise l'état avant passage en mobile
 }
 
 const initialState: NavbarState = {
     isOpen: true,
-    isClosedByUser: false,
+    wasOpened: true, 
 };
 
 const navbarSlice = createSlice({
@@ -17,20 +17,20 @@ const navbarSlice = createSlice({
     reducers: {
         toggleNavbar: (state) => {
             state.isOpen = !state.isOpen;
-            state.isClosedByUser = !state.isOpen;
+            state.wasOpened = state.isOpen; // On mémorise si elle était ouverte
         },
-        openNavbar: (state) => {
-            state.isOpen = true;
-        },
-        closeNavbar: (state) => {
-            state.isOpen = false;
+        handleResponsiveNavbar: (state, action) => {
+            if (action.payload.isMobile) {
+                state.isOpen = false; // Fermer en mobile
+            } else {
+                state.isOpen = state.wasOpened; // Rétablir l'état précédent en desktop
+            }
         }
     },
 });
 
-export const { toggleNavbar, openNavbar, closeNavbar } = navbarSlice.actions;
+export const { toggleNavbar, handleResponsiveNavbar } = navbarSlice.actions;
 
 export const selectIsNavbarOpen = (state: RootState) => state.navbar.isOpen;
-export const selectIsNavbarClosedByUser = (state: RootState) => state.navbar.isClosedByUser;
 
 export default navbarSlice.reducer;

--- a/assets/scripts/store/navbarSlice.ts
+++ b/assets/scripts/store/navbarSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '@store/store';
+
+interface NavbarState {
+    isOpen: boolean;
+    isClosedByUser: boolean;
+}
+
+const initialState: NavbarState = {
+    isOpen: true,
+    isClosedByUser: false,
+};
+
+const navbarSlice = createSlice({
+    name: 'navbar',
+    initialState,
+    reducers: {
+        toggleNavbar: (state) => {
+            state.isOpen = !state.isOpen;
+            state.isClosedByUser = !state.isOpen;
+        },
+        openNavbar: (state) => {
+            state.isOpen = true;
+        },
+        closeNavbar: (state) => {
+            state.isOpen = false;
+        }
+    },
+});
+
+export const { toggleNavbar, openNavbar, closeNavbar } = navbarSlice.actions;
+
+export const selectIsNavbarOpen = (state: RootState) => state.navbar.isOpen;
+export const selectIsNavbarClosedByUser = (state: RootState) => state.navbar.isClosedByUser;
+
+export default navbarSlice.reducer;

--- a/assets/scripts/store/store.ts
+++ b/assets/scripts/store/store.ts
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { setupListeners } from '@reduxjs/toolkit/query';
 import { djangoApi } from '@services/api';
+import navbarReducer from '@store/navbarSlice';
 import projectReducer from '@store/projectSlice';
 
 const store = configureStore({
   reducer: {
     [djangoApi.reducerPath]: djangoApi.reducer,
     project: projectReducer,
+    navbar: navbarReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(djangoApi.middleware),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,29 +10,23 @@
       "dependencies": {
         "@codegouvfr/react-dsfr": "^1.16.10",
         "@gouvfr/dsfr": "^1.8.5",
-        "@maplibre/maplibre-gl-compare": "^0.5.0",
         "@reduxjs/toolkit": "^2.2.1",
         "@remixicon/react": "^4.6.0",
         "@svgr/webpack": "^8.1.0",
         "@turf/turf": "^7.2.0",
         "@types/mapbox-gl": "^3.4.1",
         "@uidotdev/usehooks": "^2.4.1",
-        "@watergis/mapbox-gl-legend": "^1.2.6",
-        "debounce": "^2.2.0",
         "highcharts": "^11.4.6",
         "highcharts-react-official": "^3.2.1",
         "htmx.org": "^1.8.4",
         "lodash.isequal": "^4.5.0",
-        "mapbox-gl": "^3.9.3",
-        "mapbox-gl-compare": "^0.4.1",
         "maplibre-gl": "^5.0.1",
         "pmtiles": "^4.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-map-gl": "^7.1.8",
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.26.0",
-        "remixicon": "^4.6.0",
+        "react-tooltip": "^5.28.0",
         "styled-components": "^6.1.8"
       },
       "devDependencies": {
@@ -2085,6 +2079,31 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
     "node_modules/@gouvfr/dsfr": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.12.1.tgz",
@@ -2487,12 +2506,6 @@
         "geojson-rewind": "geojson-rewind"
       }
     },
-    "node_modules/@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "license": "ISC"
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -2500,80 +2513,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.28.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
-      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      },
-      "bin": {
-        "gl-style-composite": "bin/gl-style-composite.js",
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec/node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec/node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "license": "MIT"
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec/node_modules/sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec/node_modules/sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec/node_modules/sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
-      "dependencies": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
-      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@mapbox/mapbox-gl-sync-move": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-sync-move/-/mapbox-gl-sync-move-0.3.1.tgz",
-      "integrity": "sha512-Y3PMyj0m/TBJa9OkQnO2TiVDu8sFUPmLF7q/THUHrD/g42qrURpMJJ4kufq4sR60YFMwZdCGBshrbgK5v2xXWw==",
-      "license": "ISC"
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -2609,18 +2548,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@maplibre/maplibre-gl-compare": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-compare/-/maplibre-gl-compare-0.5.0.tgz",
-      "integrity": "sha512-tJ5MtbMXhVstu85NSArkvZFewV0i19qBOP4TyO6JSNFY0qV3zwGLXxmxalg1QGdi18cmKnmZT86BoLCSS0rEPg==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/mapbox-gl-sync-move": "^0.3.0"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=1.14.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
@@ -6210,135 +6137,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@watergis/legend-symbol": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@watergis/legend-symbol/-/legend-symbol-0.2.3.tgz",
-      "integrity": "sha512-bxW2nGUvL80/iLTAstvP0QRcpprKKyTOLFueDW+dD0g9PDIFYx4De6MrKp4QJPx9SmrlidPxslOB0mXZrENmUg==",
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.16.0"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@watergis/mapbox-gl-legend/-/mapbox-gl-legend-1.2.6.tgz",
-      "integrity": "sha512-0/AjT10uobNPxHntBYM7HjeoGj6fpOWsu5aBrnD3312Gn/63ko/XpjVY6P1YJ3Un4NhulTAtD4GOmpJyWDrEag==",
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.25.0",
-        "@watergis/legend-symbol": "^0.2.3",
-        "axios": "^0.27.2",
-        "mapbox-gl": "^1.13.2"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "mapbox-gl": ">=0.32.1 <2.0.0"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/@mapbox/tiny-sdf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "license": "ISC"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-      "license": "ISC"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-      "license": "ISC"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/mapbox-gl": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
-      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "license": "ISC"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "license": "ISC"
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^3.0.0"
-      }
-    },
-    "node_modules/@watergis/mapbox-gl-legend/node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "license": "ISC"
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -6755,15 +6553,6 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
@@ -6951,15 +6740,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -6987,12 +6767,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -7549,25 +7323,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "node_modules/bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -7651,12 +7406,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cheap-ruler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
-      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
-      "license": "ISC"
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -7706,6 +7455,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7758,18 +7513,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -8164,12 +7907,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -8306,18 +8043,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -8477,15 +8202,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -9969,18 +9685,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10228,20 +9932,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -10443,15 +10133,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
@@ -10589,12 +10270,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/grid-index": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
-      "license": "ISC"
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -11355,15 +11030,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11548,6 +11214,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -11744,6 +11411,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12589,55 +12257,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/mapbox-gl": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.9.3.tgz",
-      "integrity": "sha512-31mh95f35srpBMxAP32F9dKQXz7pT5VxQA5r6bFY6Aa5G6Z6NC/SVOTyWR+G/wY8wXWTHAnOaAAf5UkD5++/Kg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "workspaces": [
-        "src/style-spec",
-        "test/build/typings"
-      ],
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.15",
-        "@types/geojson-vt": "^3.2.5",
-        "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "cheap-ruler": "^4.0.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.0",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
-        "grid-index": "^1.1.0",
-        "kdbush": "^4.0.2",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^3.0.0",
-        "serialize-to-js": "^3.1.2",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
-      }
-    },
-    "node_modules/mapbox-gl-compare": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl-compare/-/mapbox-gl-compare-0.4.1.tgz",
-      "integrity": "sha512-aLE1GK5oZywGwtRWjVnVz50Fudcod6d0tIxl4X5Rv/nhE8Kc64692S37F150amYvOFzzST+ylP25KgM6ApiPRA==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/mapbox-gl-sync-move": "^0.3.1"
       }
     },
     "node_modules/maplibre-gl": {
@@ -14029,55 +13648,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-map-gl": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.8.tgz",
-      "integrity": "sha512-zwF16XMOdOKH4py5ehS1bgQIChqW8UN3b1bXps+JnADbYLSbOoUPQ3tNw0EZ2OTBWArR5aaQlhlEqg4lE47T8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^19.2.1",
-        "@types/mapbox-gl": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "mapbox-gl": ">=1.13.0",
-        "maplibre-gl": ">=1.13.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "mapbox-gl": {
-          "optional": true
-        },
-        "maplibre-gl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-map-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
-        "minimist": "^1.2.8",
-        "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/react-map-gl/node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
-      "license": "MIT"
-    },
     "node_modules/react-redux": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
@@ -14141,6 +13711,20 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
+      "integrity": "sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/readable-stream": {
@@ -14310,12 +13894,6 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
-    },
-    "node_modules/remixicon": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.6.0.tgz",
-      "integrity": "sha512-bKM5odjqE1yzVxEZGJE7F79WHhNrJFIKHXR+GG+P1IWXn8AnJZhl8SbIRDJsNAvIqx4VPkNwjuHfc42tutMDpQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -14795,15 +14373,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/serialize-to-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
-      "integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -14938,21 +14507,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -15151,41 +14705,6 @@
         "websocket-driver": "^0.7.4"
       }
     },
-    "node_modules/sort-asc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
-      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
-      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
-      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise": "^1.1.0",
-        "get-value": "^2.0.2",
-        "is-extendable": "^0.1.1",
-        "sort-asc": "^0.2.0",
-        "sort-desc": "^0.2.0",
-        "union-value": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -15263,43 +14782,6 @@
       "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
       "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "license": "BDS-3-Clause"
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -16359,21 +15841,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "node_modules/typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "license": "MIT"
-    },
     "node_modules/ua-parser-js": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
@@ -16459,21 +15926,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.26.0",
+    "react-tooltip": "^5.28.0",
     "styled-components": "^6.1.8"
   }
 }


### PR DESCRIPTION
Repris de #899 pour la création de l'app review

**Menu principal version mobile:**
<img width="953" alt="Capture d’écran 2025-02-07 à 11 36 45" src="https://github.com/user-attachments/assets/61f28d3d-1d5e-4f79-b2a3-3246968e1e15" />
<img width="957" alt="Capture d’écran 2025-02-07 à 11 36 56" src="https://github.com/user-attachments/assets/7cec07ca-491f-4a1c-8089-dce6f2914785" />


**Sidebar dashboard repliable en desktop:**
<img width="1508" alt="Capture d’écran 2025-02-07 à 11 35 49" src="https://github.com/user-attachments/assets/2adbe55d-9381-4782-8585-11eb15d1acfe" />
<img width="1510" alt="Capture d’écran 2025-02-07 à 11 36 02" src="https://github.com/user-attachments/assets/22641d5e-d1c8-408a-a29f-9efc7d4a961b" />

**Sidebar dashboard mobile:**
<img width="580" alt="Capture d’écran 2025-02-07 à 11 37 57" src="https://github.com/user-attachments/assets/ad135a8d-ddef-4e15-92b1-95697fadb5b2" />
<img width="585" alt="Capture d’écran 2025-02-07 à 11 37 24" src="https://github.com/user-attachments/assets/24658839-b6a5-41e3-9ae9-c1124972e01b" />
=> La sidebar est affichée au dessus du contenu en mobile, un overlay masque le contenu et le scroll sur le contenu est bloqué.

On facilite le clique sur les liens de téléchargement en version mobile. Il n'y a plus d'effet d'apparition des liens au hover en mobile, ils sont intégrés directement dans le scroll de la sidebar.
<img width="580" alt="Capture d’écran 2025-02-07 à 11 37 45" src="https://github.com/user-attachments/assets/36d110f4-e771-4dcd-bc9f-10569be5555e" />

**Footer version mobile:**
<img width="580" alt="Capture d’écran 2025-02-07 à 11 38 02" src="https://github.com/user-attachments/assets/6f5b8e23-6ebe-4fb4-818c-1cfdaf405863" />
