### PR TITLE
Hotfix Carte OCS Ge : ajout de la couleur manquante pour CS2.2.2

### DIFF
--- a/assets/scripts/components/map/ocsge/constants/colors.tsx
+++ b/assets/scripts/components/map/ocsge/constants/colors.tsx
@@ -20,6 +20,7 @@ export const couvertureColors: CouvertureColors = {
     "CS2.1.2": [166, 255, 128],
     "CS2.1.3": [230, 128, 0],
     "CS2.2.1": [204, 242, 77],
+    "CS2.2.2": [202, 252, 202],
 }
 
 export type UsageColors = {

--- a/assets/scripts/components/map/ocsge/constants/cs_and_us.tsx
+++ b/assets/scripts/components/map/ocsge/constants/cs_and_us.tsx
@@ -11,7 +11,8 @@ export const couvertures = [
     "CS2.1.1.3",
     "CS2.1.2",
     "CS2.1.3",
-    "CS2.2.1"
+    "CS2.2.1",
+    "CS2.2.2",
 ] as const
 export type Couverture = typeof couvertures[number]
 


### PR DESCRIPTION
hotfix du fix #953 