### PR TITLE
Revert "Correctif artif x occupation du sol : permet une valeur non officielle de l'artif"

### DIFF
--- a/airflow/include/sql/sparte/models/ocsge/occupation_du_sol_with_artif.sql
+++ b/airflow/include/sql/sparte/models/ocsge/occupation_du_sol_with_artif.sql
@@ -28,8 +28,8 @@ select
         else artif.critere_seuil
     end as critere_seuil
 from
-    {{ ref('occupation_du_sol') }}
-LEFT JOIN LATERAL (
+    {{ ref('occupation_du_sol') }},
+LATERAL (
     SELECT
         is_artificial,
         critere_seuil
@@ -39,4 +39,4 @@ LEFT JOIN LATERAL (
             occupation_du_sol.year = artif.year and
             occupation_du_sol.departement = artif.departement
         limit 1
-) as artif ON TRUE
+) as artif


### PR DESCRIPTION
Problème de performance avec `LEFT JOIN LATERAL`.
Conséquence du revert : restreint les départements d'ocsge eux départements pour lesquels l'artif a été calculée