### PR TITLE
Remplace et renomme l'url de webinaire

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -96,7 +96,7 @@
       </div>
     </div>
     <div class="d-flex justify-content-center fr-mt-4w">
-      <a href="{{ JOTFORM_URL }}" target="_blank" rel="noopener" class="fr-link--text-decoration-none">
+      <a href="{{ WEBINAIRE_URL }}" target="_blank" rel="noopener" class="fr-link--text-decoration-none">
         <button class="fr-btn">
           Participer au prochain webinaire de présentation
         </button>

--- a/required_parameters.json
+++ b/required_parameters.json
@@ -79,9 +79,9 @@
     },
     {
         "name": "URL vers le formulaire d'inscription aux webinaires",
-        "slug": "JOTFORM_URL",
+        "slug": "WEBINAIRE_URL",
         "value_type": "STR",
-        "value": "https://form.jotform.com/231703451991355",
+        "value": "https://app.livestorm.co/mte/mon-diag-artif-webinaire-de-presentation?s=7425e75c-4336-47c8-acd2-5459b8261af6",
         "is_global": true
     },
     {

--- a/users/tests/parameters.json
+++ b/users/tests/parameters.json
@@ -148,10 +148,10 @@
         "pk": 13,
         "fields": {
             "name": "URL vers le formulaire d'inscription aux webinaires",
-            "slug": "JOTFORM_URL",
+            "slug": "WEBINAIRE_URL",
             "value_type": "STR",
             "description": "",
-            "value": "https://form.jotform.com/231703451991355",
+            "value": "https://app.livestorm.co/mte/mon-diag-artif-webinaire-de-presentation?s=7425e75c-4336-47c8-acd2-5459b8261af6",
             "is_global": true
         }
     },


### PR DESCRIPTION
La valeur de JOTFORM_URL a été remplacée directement en prod par celle de la PR, le renommage de cette PR est pour rendre la variable agnostique de l'outil.