### PR TITLE
Prise en compte du cas où le territoire n'a pas d'OCS GE

### DIFF
--- a/assets/scripts/components/features/status/OcsgeStatus.tsx
+++ b/assets/scripts/components/features/status/OcsgeStatus.tsx
@@ -11,7 +11,7 @@ export interface OcsgeStatusProps {
     status: "COMPLETE_UNIFORM" | "COMPLETE_NOT_UNIFORM" | "PARTIAL" | "NO_DATA" | "UNDEFINED";
 }
 
-const defaultMessage = "Les données OCS GE ne sont pas encore disponibles sur ce territoire pour les dates sélectionnées.";
+const defaultMessage = "Les données OCS GE ne sont pas encore disponibles sur ce territoire.";
 const detailMessage = "Vous n'avez donc pas accès aux informations relatives à l'artificialisation, l'imperméabilisation, l'usage et la couverture.";
 const errorMessage = `${defaultMessage} ${detailMessage}`;
 

--- a/assets/scripts/components/layout/Dashboard.tsx
+++ b/assets/scripts/components/layout/Dashboard.tsx
@@ -55,11 +55,6 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
             skip: !projectData
         }
     );
-
-    const { landArtifStockIndex } = useArtificialisation({
-        projectData: projectData as any,
-        landData: landData as any
-    });
     
     const { urls } = projectData || {};
 
@@ -91,23 +86,10 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
                                                 title="Synthèse"
                                                 consoCorrectionStatus={projectData.consommation_correction_status}
                                             >
-                                                <Synthese 
+                                                <Synthese
                                                     endpoint={urls.synthese}
                                                     urls={projectData.urls}
-                                                    artificialisationData={landArtifStockIndex ? {
-                                                        surface: landArtifStockIndex.surface,
-                                                        percent: landArtifStockIndex.percent,
-                                                        flux_surface: landArtifStockIndex.flux_surface,
-                                                        years: landArtifStockIndex.years,
-                                                        is_interdepartemental: landData.is_interdepartemental,
-                                                        millesime_index: landArtifStockIndex.millesime_index,
-                                                        flux_previous_years: landArtifStockIndex.flux_previous_years,
-                                                        millesimes: landData.millesimes,
-                                                        territory_name: projectData.territory_name,
-                                                        land_type: projectData.land_type,
-                                                        land_id: projectData.land_id,
-                                                        millesimes_by_index: landData.millesimes_by_index
-                                                    } : undefined}
+                                                    landData={landData}
                                                 />
                                             </RouteWrapper>
                                         }
@@ -138,7 +120,9 @@ const Dashboard: React.FC<DashboardProps> = ({ projectId }) => {
                                         path={urls.artificialisation}
                                         element={
                                             <RouteWrapper
-                                                title="Artificialisation des sols">
+                                                title="Artificialisation des sols"
+                                                ocsgeStatus={landData.has_ocsge ? 'COMPLETE_UNIFORM' : 'NO_DATA'}
+                                            >
                                                     <Artificialisation
                                                         projectData={projectData}
                                                         landData={landData}

--- a/assets/scripts/components/pages/Artificialisation.tsx
+++ b/assets/scripts/components/pages/Artificialisation.tsx
@@ -189,7 +189,6 @@ export const Artificialisation: React.FC<ArtificialisationProps> = ({
 		isLoading,
 		error
 	} = useArtificialisation({
-		projectData,
 		landData
 	});
 

--- a/assets/scripts/components/pages/Synthese.tsx
+++ b/assets/scripts/components/pages/Synthese.tsx
@@ -5,9 +5,8 @@ import Loader from '@components/ui/Loader';
 import { formatNumber } from "@utils/formatUtils";
 import { MillesimeDisplay } from "@components/features/ocsge/MillesimeDisplay";
 import { LandMillesimeTable } from "@components/features/ocsge/LandMillesimeTable";
-import { Millesime, MillesimeByIndex } from "@services/types/land";
+import { LandDetailResultType, Millesime, MillesimeByIndex } from "@services/types/land";
 import { useArtificialisation } from "@hooks/useArtificialisation";
-import { ProjectDetailResultType } from "@services/types/project";
 
 /*
 Ce composant est un composant hybride qui permet de récupérer du contenu côté serveur via Django et de l'intégrer directement dans l'interface React.
@@ -39,17 +38,11 @@ interface UrlsType {
 }
 
 const ArtificialisationSection: React.FC<{ 
-    data: ArtificialisationData;
     urls: UrlsType;
-}> = ({ data, urls }) => {
-    const { landArtifStockIndex, isLoading, error } = useArtificialisation({
-        projectData: {
-            land_type: data.land_type,
-            land_id: data.land_id
-        } as ProjectDetailResultType,
-        landData: {
-            millesimes_by_index: data.millesimes_by_index
-        } as any
+    landData: LandDetailResultType;
+}> = ({ landData, urls }) => {
+    const { landArtifStockIndex : data, isLoading, error } = useArtificialisation({
+        landData
     });
 
     if (isLoading) return <Loader />;
@@ -66,8 +59,8 @@ const ArtificialisationSection: React.FC<{
                             Surface artificialisée
                             {" "}
                             <MillesimeDisplay 
-                                is_interdepartemental={data.is_interdepartemental}
-                                landArtifStockIndex={landArtifStockIndex}
+                                is_interdepartemental={landData.is_interdepartemental}
+                                landArtifStockIndex={data}
                             />
                         </p>
                         <span className={`fr-badge ${
@@ -86,8 +79,8 @@ const ArtificialisationSection: React.FC<{
                             )}
                         </span>
                         <MillesimeDisplay 
-                            is_interdepartemental={data.is_interdepartemental}
-                            landArtifStockIndex={landArtifStockIndex}
+                            is_interdepartemental={landData.is_interdepartemental}
+                            landArtifStockIndex={data}
                             between={true}
                             className="fr-text--sm fr-ml-1w"
                         />
@@ -103,9 +96,9 @@ const ArtificialisationSection: React.FC<{
             
             <div className="fr-my-3w">
                 <LandMillesimeTable 
-                    millesimes={data.millesimes}
-                    territory_name={data.territory_name}
-                    is_interdepartemental={data.is_interdepartemental}
+                    millesimes={landData.millesimes}
+                    territory_name={landData.name}
+                    is_interdepartemental={landData.is_interdepartemental}
                 />
             </div>
             
@@ -117,8 +110,8 @@ const ArtificialisationSection: React.FC<{
 const Synthese: React.FC<{ 
     endpoint: string; 
     urls: UrlsType; 
-    artificialisationData?: ArtificialisationData 
-}> = ({ endpoint, urls, artificialisationData }) => {
+    landData?: LandDetailResultType; 
+}> = ({ endpoint, urls, landData }) => {
     const { content, isLoading, error } = useHtmlLoader(endpoint);
 
     if (isLoading) return <Loader />;
@@ -131,7 +124,7 @@ const Synthese: React.FC<{
                     <div dangerouslySetInnerHTML={{ __html: content }} />
                 </div>
             </div>
-            {artificialisationData && <ArtificialisationSection data={artificialisationData} urls={urls} />}
+            {landData?.has_ocsge && <ArtificialisationSection landData={landData} urls={urls} />}
         </div>
     );
 };

--- a/assets/scripts/hooks/useArtificialisation.ts
+++ b/assets/scripts/hooks/useArtificialisation.ts
@@ -1,12 +1,10 @@
 import { useState } from 'react';
 import { useGetLandArtifStockIndexQuery } from '@services/api';
-import { ProjectDetailResultType } from '@services/types/project';
 import { LandDetailResultType } from '@services/types/land';
 import { LandArtifStockIndex, defautLandArtifStockIndex } from '@services/types/landartifstockindex';
 import { useMemo } from 'react';
 
 interface UseArtificialisationProps {
-    projectData: ProjectDetailResultType;
     landData: LandDetailResultType;
 }
 
@@ -27,7 +25,6 @@ interface UseArtificialisationReturn {
 }
 
 export const useArtificialisation = ({
-    projectData,
     landData
 }: UseArtificialisationProps): UseArtificialisationReturn => {
     // Millésime par défaut
@@ -51,11 +48,11 @@ export const useArtificialisation = ({
 
     // Récupération des données d'artificialisation
     const { data: landArtifStockIndexes, isLoading, error } = useGetLandArtifStockIndexQuery({
-        land_type: projectData?.land_type,
-        land_id: projectData?.land_id,
+        land_type: landData?.land_type,
+        land_id: landData?.land_id,
         millesime_index: defaultStockIndex,
     }, {
-        skip: !projectData
+        skip: !landData
     });
 
     // Récupère les données d'artificialisation du millésime sélectionné

--- a/assets/scripts/services/types/land.tsx
+++ b/assets/scripts/services/types/land.tsx
@@ -35,6 +35,8 @@ export type Millesime = {
     parent_keys: string[];
     departements: string[];
     is_interdepartemental: boolean;
+    has_zonage: boolean;
+    has_ocsge: boolean;
   };
 
   type LandDetailQueryArg = string | FetchArgs | {

--- a/public_data/models/administration/LandModel.py
+++ b/public_data/models/administration/LandModel.py
@@ -6,8 +6,6 @@ from django.views.decorators.cache import cache_control, cache_page
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 
-from .Departement import Departement
-
 
 class LandModel(models.Model):
     land_id = models.CharField()
@@ -38,23 +36,6 @@ class LandModel(models.Model):
 
 
 class LandModelSerializer(serializers.ModelSerializer):
-    def get_departement_name(self, departement_id):
-        try:
-            departement = Departement.objects.get(source_id=departement_id)
-            return departement.name
-        except Departement.DoesNotExist:
-            return departement_id
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-
-        # Ajouter le nom du département pour chaque millésime
-        for millesime in data["millesimes"]:
-            if "departement" in millesime:
-                millesime["departement_name"] = self.get_departement_name(millesime["departement"])
-
-        return data
-
     class Meta:
         model = LandModel
         exclude = ("geom",)


### PR DESCRIPTION
- Suppression de la dépendance à `ProjectData` de `useArtificialisation ` -> comme on souhaite passer sur des diagnostics territoriaux il faudrait qu'on évite d'ajouter des dépendances à Project si on peut
- Passé le status OCS GE à `routeWrapper` pour l'affichage conditionnel de la page OCS GE. J'ai utilisé le boolean `has_ocsge` de `LandData`, mais il faudrait utiliser le status complet pour afficher un message qui a du sens / masquer les territoires pas complétement couvert par l'OCS GE (ça reste très minoritaire pour la MEP donc pas besoin de les prendre en compte dès maintenant)
- Déplacé les appels aux hooks de donnée au plus proche de leur utilisation
- Supprimé le `to_representation ` temporaire de `LandModelSerializer ` -> la donnée a été ajoutée à la table via DBT