### PR TITLE
Changement du texte sur le seuil + précision sur le gonflage des zones baties

### DIFF
--- a/assets/scripts/components/features/ocsge/SeuilsSchemas.tsx
+++ b/assets/scripts/components/features/ocsge/SeuilsSchemas.tsx
@@ -138,6 +138,7 @@ const Arrow = styled.div`
 
 export const SeuilsSchemas = () => {
 	return (
+		<>
 		<div className="fr-grid-row fr-grid-row--gutters">
 			<SchemaPair className="fr-col-12 fr-col-lg-4">
 				<span className="fr-badge">1</span>
@@ -147,7 +148,7 @@ export const SeuilsSchemas = () => {
 					<ArtificializedSquare className="with-threshold" />
 				</div>
 				<p className="fr-text--sm text-center fr-mt-2w fr-mb-0 fr-text--bold">
-					Une zone non-artificielle de moins de 2500 m² enclavée dans une zone
+					Une surface non-artificielle de moins de 2500 m² enclavée dans une surface
 					artificielle devient artificielle.
 				</p>
 			</SchemaPair>
@@ -160,7 +161,7 @@ export const SeuilsSchemas = () => {
 					<NonArtificializedSquare className="with-threshold" />
 				</div>
 				<p className="fr-text--sm text-center fr-mt-2w fr-mb-0 fr-text--bold">
-					Une zone artificielle de moins de 2500 m² enclavée dans une zone
+					Une surface artificielle de moins de 2500 m² enclavée dans une surface
 					non-artificielle devient non-artificielle.
 				</p>
 			</SchemaPair>
@@ -173,10 +174,25 @@ export const SeuilsSchemas = () => {
 					<ConstructionSquare className="with-threshold" />
 				</div>
 				<p className="fr-text--sm text-center fr-mt-2w fr-mb-0 fr-text--bold">
-					Une zone bâtie de plus de 50 m² enclavée dans une zone
-					non-artificielle est toujours artificielle.
+					Une surface bâtie de plus de 50 m² enclavée dans une surface
+					non-artificielle est toujours artificielle*.
 				</p>
 			</SchemaPair>
+			
 		</div>
+		<p>
+			<small>
+				<i>* Concernant les surfaces bâties : bien que la réglementation précise
+					qu'une surface bâtie est toujours considérée comme artificielle
+					à partir de 50m2, il est important de noter qu'avec les données 
+					OCS GE, les surfaces bâties comprises entre 50m2 et 200m2
+					sont gonflées à 200m2. <a target="_blank" href="https://storymaps.arcgis.com/stories/193550c4e4af4f92845201d74ca8a002">
+						Source
+					</a>
+
+				</i>
+			</small>
+		</p>
+		</>
 	);
 };


### PR DESCRIPTION
- Remplacement des termes "zone" par "surface" #1135 
- Précision du cas des surfaces bâties avec l'OCS GE #1089 

![image](https://github.com/user-attachments/assets/a7f91bae-c2f6-46b6-95c8-5cff3cec5d0b)
