### PR TITLE
Fix brevo : only import to list #10

### DIFF
--- a/airflow/dags/update_brevo.py
+++ b/airflow/dags/update_brevo.py
@@ -67,11 +67,8 @@ def update_brevo():
         brevo = InfraContainer().brevo()
         with open(local_tmp_file, "r") as file:
             contact_csv_str = file.read()
-
-        if os.getenv("ENVIRONMENT") == "production":
-            list_ids = [10]
-        else:
-            list_ids = [26]
+        list_ids = [10]
+        # TODO : different env with different list ids
         return brevo.import_contacts(contact_csv_str, list_ids=list_ids)
 
     build_suv = build_suv_on_dbt()


### PR DESCRIPTION
This pull request makes a small update to the `import_brevo_contacts` function by removing the environment-based logic that selected different `list_ids` for production and non-production environments. Now, `list_ids` is always set to `[10]`, with a TODO comment indicating the intention to support different environments in the future.

* Removed conditional logic for setting `list_ids` based on the `ENVIRONMENT` variable; now always uses `[10]` and added a TODO comment for future environment support.…ortation des contacts