### PR TITLE
Ajoute l'année 2023 au graphique de conso x logements vacants

### DIFF
--- a/project/views/diagnostic/DiagnosticLogementVacantView.py
+++ b/project/views/diagnostic/DiagnosticLogementVacantView.py
@@ -28,7 +28,7 @@ class DiagnosticLogementVacantView(DiagnosticBaseView):
         project: Project = self.get_object()
         start_date = 2019
         end_date = 2023
-        end_date_conso = 2022
+        end_date_conso = 2023
         has_logement_vacant = project.logements_vacants_available
         has_autorisation_logement = project.autorisation_logement_available
 


### PR DESCRIPTION
fixes #1305 

This pull request makes a small update to the `DiagnosticLogementVacantView.py` view, extending the `end_date_conso` value from 2022 to 2023 to match the `end_date`. This ensures consistency in the date ranges used for diagnostics.

- Updated `end_date_conso` to 2023 in `get_context_data` to align with the main `end_date`.