### PR TITLE
Fix addlookalike

### DIFF
--- a/project/views/crud.py
+++ b/project/views/crud.py
@@ -110,6 +110,11 @@ class ProjectAddLookALike(GroupMixin, RedirectURLMixin, FormMixin, DetailView):
     context_object_name = "project"
     form_class = KeywordForm
 
+    @property
+    def object(self):
+        # hotfix to make this view work
+        return super().get_object()
+
     def form_valid(self, form):
         """If the form is valid, redirect to the supplied URL."""
         kwargs = {"results": Land.search(form.cleaned_data["keyword"], search_for="*"), "form": form}


### PR DESCRIPTION
This pull request introduces a hotfix to the `ProjectAddLookALike` view to ensure it works correctly. The main change is the addition of an `object` property that returns the result of `get_object()` from the superclass.

Functional hotfix:

* Added an `object` property to the `ProjectAddLookALike` class in `project/views/crud.py` to ensure the view retrieves the correct object instance, addressing a compatibility or functionality issue.