### PR TITLE
Ajustement des bornes de la période de référence sur les graphiques

### DIFF
--- a/project/charts/ObjectiveChart.py
+++ b/project/charts/ObjectiveChart.py
@@ -29,8 +29,8 @@ class ObjectiveChart(ProjectChart):
             "plotBands": [
                 {
                     "color": "#e5f3ff",
-                    "from": -1,
-                    "to": 9,
+                    "from": -0.5,
+                    "to": 9.5,
                     "label": {
                         "text": "Période de référence de la loi Climat & Résilience",
                         "style": {"color": "#95ceff", "fontWeight": "bold"},

--- a/project/charts/consommation/ConsoAnnualChart.py
+++ b/project/charts/consommation/ConsoAnnualChart.py
@@ -67,8 +67,8 @@ class ConsoAnnualChart(DiagnosticChart):
                 "plotBands": [
                     {
                         "color": "#e5f3ff",
-                        "from": 0,
-                        "to": 11,
+                        "from": -0.5,
+                        "to": 9.5,
                         "label": {
                             "text": "Période de référence de la loi Climat & Résilience",
                             "style": {"color": "#95ceff", "fontWeight": "bold"},


### PR DESCRIPTION
Graphiques corrigés :

<img width="2434" height="1072" alt="image" src="https://github.com/user-attachments/assets/6b40e389-6df5-4e49-b798-59636c837855" />

<img width="1268" height="1018" alt="image" src="https://github.com/user-attachments/assets/1c884932-4e8f-479b-96cb-2f7fea66d9fd" />

This pull request adjusts the display range for plot bands in two different chart classes to improve the visual alignment with the underlying data. The main changes involve updating the `from` and `to` values for the plot bands to better match the intended reference periods.

**Chart display improvements:**

* Updated the `plotBands` range in `ObjectiveChart` (`project/charts/ObjectiveChart.py`) by changing the `from` value from `-1` to `-0.5` and the `to` value from `9` to `9.5`, ensuring the reference period band aligns more accurately with the data.
* Updated the `plotBands` range in `ConsoAnnualChart` (`project/charts/consommation/ConsoAnnualChart.py`) by changing the `from` value from `0` to `-0.5` and the `to` value from `11` to `9.5`, for improved alignment of the reference period band.