### PR TITLE
fix: remplacer _mtm par _paq pour la gestion du suivi Matomo

### DIFF
--- a/frontend/scripts/hooks/useMatomoTracking.ts
+++ b/frontend/scripts/hooks/useMatomoTracking.ts
@@ -1,36 +1,26 @@
-import { useGetEnvironmentQuery } from '@services/api';
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const isMatomoEnabled = (): boolean => {
-    if (typeof window === 'undefined') return false;
-    
-    const metaTag = document.querySelector('meta[name="matomo-enabled"]');
-    return metaTag?.getAttribute('content') === 'true';
-};
+    const isMatomoEnabled = () => {
+        if (typeof window === 'undefined') return false;
+        
+        const metaTag = document.querySelector('meta[name="matomo-enabled"]');
+        return metaTag?.getAttribute('content') === 'true';
+    };
 
 const useMatomoTracking = (): void => {
     const location = useLocation();
-    const { data: env } = useGetEnvironmentQuery(null)
 
     useEffect(() => {
         if (!isMatomoEnabled()) {
+            console.log('Matomo tracking is disabled.');
             return;
         }
-        if (!env?.matomo_container_src) {
-            return;
-        }
-    
-        const d = document
-        const g = d.createElement('script')
-        const s = d.getElementsByTagName('script')[0]
-        g.async = true
-        g.src = env.matomo_container_src;
-        s.parentNode.insertBefore(g,s)
-
-        window._mtm!.push({'event': 'mtm.PageView'});
-
-    }, [location, env]);
+        _paq.push(['setCustomUrl', location.pathname]);
+        _paq.push(['setDocumentTitle', document.title]);
+        _paq.push(['trackPageView']);
+        console.log(location.pathname, document.title)
+    }, [location]);
 };
 
 export default useMatomoTracking;

--- a/frontend/scripts/hooks/useMatomoTracking.ts
+++ b/frontend/scripts/hooks/useMatomoTracking.ts
@@ -13,13 +13,11 @@ const useMatomoTracking = (): void => {
 
     useEffect(() => {
         if (!isMatomoEnabled()) {
-            console.log('Matomo tracking is disabled.');
             return;
         }
         _paq.push(['setCustomUrl', location.pathname]);
         _paq.push(['setDocumentTitle', document.title]);
         _paq.push(['trackPageView']);
-        console.log(location.pathname, document.title)
     }, [location]);
 };
 

--- a/frontend/types/globals.d.ts
+++ b/frontend/types/globals.d.ts
@@ -1,9 +1,9 @@
-declare var _mtm: any;
+declare var _paq: any;
 
 interface Window {
     htmx?: any;
     bootstrap?: any;
-    _mtm?: any[];
+    _paq?: any[];
     dataLayer?: any[];
     gtag?: Function;
 }

--- a/utils/templates/utils/matomo_code.html
+++ b/utils/templates/utils/matomo_code.html
@@ -1,17 +1,44 @@
 {% if MATOMO_ACTIVATE %}
-<!-- Matomo Tag Manager -->
 <meta name="matomo-enabled" content="true">
 <script nonce="[NONCE_PLACEHOLDER]">
-  var _mtm = window._mtm = window._mtm || [];
-  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-  {% if REQUEST.user.is_authenticated %}
-  _mtm.push({'UserID': '{{ REQUEST.user.email }}' });
+    var _paq = window._paq = window._paq || [];
+    {% if REQUEST.user.is_authenticated %}
+      _paq.push(['setUserId', '{{ REQUEST.user.email }}']);
     {% endif %}
-  (function() {
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src='{{ MATOMO_CONTAINER_SRC }}'; s.parentNode.insertBefore(g,s);
-  })();
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://stats.beta.gouv.fr/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '17']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
 </script>
+
+<script nonce="[NONCE_PLACEHOLDER]">
+    var DEBUG = {{ DEBUG|lower }};
+
+    function trackEvent(category, action, name) {
+        if (typeof _paq !== 'undefined') {
+            _paq.push(['trackEvent', category, action, name]);
+
+            if (DEBUG) {
+                console.log('Matomo: Event sent:', {
+                    category: category,
+                    action: action,
+                    name: name
+                });
+            }
+        } else {
+            console.warn('_paq is not defined. Event not sent:', category, action, name);
+        }
+    }
+</script>
+
+<noscript>
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://stats.beta.gouv.fr/matomo.php?idsite=17&amp;rec=1" style="border:0" alt="" />
+</noscript>
+{% else %}
+<!-- Matomo is not activated -->
 {% endif %}
-
-


### PR DESCRIPTION
This pull request refactors the Matomo analytics integration by updating both the frontend tracking logic and the HTML template. The changes simplify the tracking setup, remove the dependency on backend-provided configuration for Matomo, and standardize the use of the `_paq` array for tracking events. Additionally, a utility function for tracking custom events is introduced in the template, and debug logging is improved.

**Frontend tracking logic updates:**

- Removed the dependency on `useGetEnvironmentQuery` and environment-based Matomo container source; now, tracking is solely controlled by the presence of a meta tag (`matomo-enabled`). The tracking script uses the global `_paq` array to send page view and metadata events. [[1]](diffhunk://#diff-02072db4794d73a849e04d2c723e94c4ba440608e1a8adb13e401b1d85036742L1-R4) [[2]](diffhunk://#diff-02072db4794d73a849e04d2c723e94c4ba440608e1a8adb13e401b1d85036742L14-R23)

**Matomo template improvements:**

- Standardized the Matomo tracking code to use `_paq` instead of `_mtm`, set the tracker URL and site ID directly in the template, and improved support for authenticated user tracking.
- Added a utility JavaScript function `trackEvent` for sending custom events to Matomo, including debug logging when enabled.
- Added a `<noscript>` fallback for users without JavaScript, ensuring page views are still tracked.